### PR TITLE
Fix Route tables and add peering connection routes

### DIFF
--- a/infra/galaxy-api.tf
+++ b/infra/galaxy-api.tf
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "galaxy-api-execution-role" {
 resource "aws_ecs_task_definition" "galaxy-api" {
   family       = "galaxy-api"
   network_mode = "awsvpc"
-  memory       = 258
+  memory       = 512
 
   container_definitions = jsonencode([
     {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -14,7 +14,7 @@ variable "instance_types" {
   default = {
     api_server     = "t3.micro"
     file_processor = "r6g.xlarge"
-    database       = "db.t4g.large"
+    database       = "db.t4g.micro"
   }
 }
 
@@ -101,4 +101,9 @@ variable "debfile_name" {
 variable "libpqxx_version" {
   type    = string
   default = "7.6.1"
+}
+
+variable "tasking-manager_vpc_id" {
+  type    = string
+  default = "vpc-ea28198f"
 }


### PR DESCRIPTION
- Add peering connection from vpc to tasking manager VPC
- Add route via peering connection to public route table
- Add explicit private route table with routes via NAT and PCX
- Add route via peering connection to private route table
- Reset Database instance class to db.t4g.micro