### PR TITLE
Allow ECS containers to access secret manager

### DIFF
--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -9,5 +9,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.1.0"
 }

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -1,3 +1,11 @@
 // output "underpass_instance_state" {
 //   value = aws_instance.api[0].instance_state
 // }
+
+output "db-secret-arn" {
+  value = aws_secretsmanager_secret.underpass_database_credentials.arn
+}
+
+output "db-secret-version-arn" {
+  value = aws_secretsmanager_secret_version.underpass_database_credentials.arn
+}


### PR DESCRIPTION
- ECS Containers cannot reach secrets manager due to change in FARGATE
  v4. Therefore, create a VPC endpoint to AWS Secrets Manager service
  and attach it to the route table / subnets that the containers use.

- Increase required terraform version to 1.1.0
- Begin renaming resources Underpass --> Galaxy (Safely)
- Add VPC endpoint resource and associated security group that allows
  HTTPS connections from the VPC CIDR
- Add outputs for secrets ARN