### PR TITLE
Associate subnet (not rtb) for VPC Endpoint

### DIFF
--- a/infra/galaxy-api.tf
+++ b/infra/galaxy-api.tf
@@ -135,7 +135,7 @@ resource "aws_ecs_service" "galaxy-api" {
   propagate_tags = "SERVICE"
 
   network_configuration {
-    subnets         = aws_subnet.public.*.id
+    subnets         = aws_subnet.public[*].id
     security_groups = [aws_security_group.api.id]
     // assign_public_ip = true // valid only for FARGATE
   }
@@ -151,7 +151,7 @@ resource "aws_lb" "osm-stats" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.api.id]
-  subnets            = aws_subnet.public.*.id
+  subnets            = aws_subnet.public[*].id
 
   enable_deletion_protection = false
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -141,7 +141,7 @@ resource "aws_route" "private-to-peering-connection" {
 resource "aws_route_table_association" "private" {
   count          = var.subnet_count
   subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_vpc.underpass.default_route_table_id
+  route_table_id = aws_route_table.private.id
 }
 
 resource "aws_route_table_association" "public" {
@@ -304,7 +304,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   service_name      = "com.amazonaws.us-east-1.secretsmanager" // TODO: use var.aws_region
   auto_accept       = true
 
-  route_table_ids = [aws_route_table.private.id, aws_route_table.public.id]
+  subnet_ids = concat(aws_subnet.private[*].id, aws_subnet.public[*].id)
 
   security_group_ids = [aws_security_group.vpc-endpoint.id]
 }


### PR DESCRIPTION
- VPC Endpoints of "Interface" type - which the secretsmanager
  endpoint is - need to be associated to Subnets.

  Only Gateway-type endpoints can be associated to route-tables

  Fixed that.

- Improve splat expressions to modern standards
- Move private subnets to explicit private route-table instead of
  leaving them associated with the Default route-table