### PR TITLE
Fix new changesets

### DIFF
--- a/galaxy/planetreplicator.cc
+++ b/galaxy/planetreplicator.cc
@@ -147,9 +147,9 @@ PlanetReplicator::PlanetReplicator(void) {
     StateFile state7("/004/000/000", 3000000, time7, replication::changeset);
     default_changesets.push_back(state7);
 
-    // ptime time6 = time_from_string("2022-04-03 16:25:35");
-    // StateFile state6("/005/000/000", 3000000, time6, replication::changeset);
-    // default_changesets.push_back(state6);
+    ptime time6 = time_from_string("2022-04-03 16:25:35");
+    StateFile state6("/005/000/000", 3000000, time6, replication::changeset);
+    default_changesets.push_back(state6);
 };
 
 /// Initialize the raw_user, raw_hashtags, and raw_changeset tables
@@ -342,3 +342,7 @@ std::shared_ptr<RemoteURL> PlanetReplicator::findRemotePath(const replicatorconf
 
 } // namespace planetreplicator
 
+// local Variables:
+// mode: C++
+// indent-tabs-mode: t
+// End:

--- a/testsuite/libunderpass.all/Makefile.am
+++ b/testsuite/libunderpass.all/Makefile.am
@@ -28,7 +28,7 @@ check_PROGRAMS = \
 	osm2pgsql-test \
 	yaml-test \
 	stats-test \
-	rep-test \
+	planetreplicator-test \
 	geo-test
 
 TOPSRC := $(shell cd $(top_srcdir) && pwd)
@@ -102,10 +102,10 @@ stats_test_SOURCES = stats-test.cc
 stats_test_LDFLAGS = -L../..
 stats_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
 
-# Test the Replicator class
-rep_test_SOURCES = rep-test.cc
-rep_test_LDFLAGS = -L../..
-rep_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
+# Test the PlanetReplicator class
+planetreplicator_test_SOURCES = planetreplicator-test.cc
+planetreplicator_test_SOURCES = -L../..
+planetreplicator_test_SOURCES = -lpqxx -lunderpass $(BOOST_LIBS)
 
 # Test the Changeset class
 change_test_SOURCES = change-test.cc
@@ -135,7 +135,7 @@ CLEANFILES = \
 	geo-test.log \
 	osm2pgsql-test.log \
 	stats-test.log \
-	rep-test.log \
+	planetreplicator-test.log \
 	replication-test.log
 
 RUNTESTFLAGS = -xml

--- a/testsuite/libunderpass.all/Makefile.am
+++ b/testsuite/libunderpass.all/Makefile.am
@@ -104,8 +104,8 @@ stats_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
 
 # Test the PlanetReplicator class
 planetreplicator_test_SOURCES = planetreplicator-test.cc
-planetreplicator_test_SOURCES = -L../..
-planetreplicator_test_SOURCES = -lpqxx -lunderpass $(BOOST_LIBS)
+planetreplicator_test_LDFLAGS = -L../..
+planetreplicator_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
 
 # Test the Changeset class
 change_test_SOURCES = change-test.cc

--- a/testsuite/libunderpass.all/change-test.cc
+++ b/testsuite/libunderpass.all/change-test.cc
@@ -169,6 +169,33 @@ main(int argc, char *argv[])
         runtest.fail("ChangeSetFile::readChanges(parsed file)");
     }
 
+    // Tracking all changeset from file
+    std::vector<long> changeset_ids = {8580445, 94802322, 98934881, 98935384, 98935857, 99055952, 99056962, 99062100, 99063443, 99069702, 99069879};
+    std::map<long, long> changeset_ids_found;
+    for (const auto &change: testco.changes) {
+        for (const auto &node: change->nodes) {
+            changeset_ids_found.insert(std::pair<long, long>(node->change_id, node->change_id));
+        }
+        for (const auto &way: change->ways) {
+            changeset_ids_found.insert(std::pair<long, long>(way->change_id, way->change_id));
+        }
+        for (const auto &relation: change->relations) {
+            changeset_ids_found.insert(std::pair<long, long>(relation->change_id, relation->change_id));
+        }
+    }
+    bool all_changesets_tracked = true;
+    for (auto it = std::begin(changeset_ids); it != std::end(changeset_ids); ++it) {
+        if (!changeset_ids_found.count(*it)) {
+            all_changesets_tracked = false;
+            break;
+        }
+    }
+    if (all_changesets_present) {
+        runtest.pass("ChangeSetFile::readChanges(tracking all changesets from file)");
+    } else {
+        runtest.fail("ChangeSetFile::readChanges(tracking all changesets from file)");
+    }
+
     auto tf = testco.changes.front();
     auto tnf = tf->nodes.front();
     if (tnf->change_id == 99069702 && tnf->id == 5776216755) {

--- a/testsuite/libunderpass.all/change-test.cc
+++ b/testsuite/libunderpass.all/change-test.cc
@@ -190,7 +190,7 @@ main(int argc, char *argv[])
             break;
         }
     }
-    if (all_changesets_present) {
+    if (all_changesets_tracked) {
         runtest.pass("ChangeSetFile::readChanges(tracking all changesets from file)");
     } else {
         runtest.fail("ChangeSetFile::readChanges(tracking all changesets from file)");

--- a/testsuite/libunderpass.all/planetreplicator-test.cc
+++ b/testsuite/libunderpass.all/planetreplicator-test.cc
@@ -47,7 +47,7 @@ main(int argc, char *argv[]) {
 
     logger::LogFile &dbglogfile = logger::LogFile::getDefaultInstance();
     dbglogfile.setWriteDisk(true);
-    dbglogfile.setLogFilename("rep-test.log");
+    dbglogfile.setLogFilename("planetreplicator-test.log");
     dbglogfile.setVerbosity(3);
 
     ReplicatorConfig config;
@@ -94,7 +94,7 @@ main(int argc, char *argv[]) {
                 auto start_time_string = to_simple_string(config.start_time);
 
                 time_duration delta = timestamp - config.start_time;
-                if (delta.hours() > -24 && delta.hours() < 24) {
+                if (delta.hours() > -24 && delta.hours() < 12) {
                     runtest.pass("Find remote path from timestamp +/- 1 day (" + start_time_string + ") (" + timestamp_string + ")");
                 } else {
                     runtest.fail("Find remote path from timestamp +/- 1 day (" + start_time_string + ") (" + timestamp_string + ")");

--- a/testsuite/libunderpass.all/planetreplicator-test.cc
+++ b/testsuite/libunderpass.all/planetreplicator-test.cc
@@ -22,6 +22,7 @@
 #include <vector>
 #include "log.hh"
 #include "boost/date_time/posix_time/posix_time.hpp"
+#include <boost/program_options.hpp>
 #include "galaxy/osmchange.hh"
 #include "replicatorconfig.hh"
 #include "galaxy/planetreplicator.hh"
@@ -34,6 +35,8 @@ using namespace planetreplicator;
 using namespace replication;
 using namespace boost::posix_time;
 
+namespace opts = boost::program_options;
+
 class TestCO : public osmchange::OsmChangeFile {
 };
 
@@ -41,6 +44,32 @@ class TestPlanet : public replication::Planet {
 };
 
 TestState runtest;
+
+void testPath(ReplicatorConfig config) {
+    planetreplicator::PlanetReplicator replicator;
+    auto osmchange = replicator.findRemotePath(config, config.start_time);
+    TestCO change;
+    if (boost::filesystem::exists(osmchange->filespec)) {
+        change.readChanges(osmchange->filespec);
+    } else { 
+        TestPlanet planet;
+        auto data = planet.downloadFile(osmchange->getURL());
+        auto xml = planet.processData(osmchange->filespec, *data);
+        std::istream& input(xml);
+        change.readXML(input);
+    }
+
+    ptime timestamp = change.changes.back()->final_entry;
+    auto timestamp_string_debug = to_simple_string(timestamp);
+    auto start_time_string_debug = to_simple_string(config.start_time);
+
+    time_duration delta = timestamp - config.start_time;
+    if (delta.hours() > -24 && delta.hours() < 24) {
+        runtest.pass("Find remote path from timestamp +/- 1 day (" + start_time_string_debug + ") (" + timestamp_string_debug + ")");
+    } else {
+        runtest.fail("Find remote path from timestamp +/- 1 day (" + start_time_string_debug + ") (" + timestamp_string_debug + ")");
+    }
+}
 
 int
 main(int argc, char *argv[]) {
@@ -53,51 +82,44 @@ main(int argc, char *argv[]) {
     ReplicatorConfig config;
     config.planet_server = config.planet_servers[0].domain + "/replication";
 
-    std::vector<std::string> dates = {
-        "-01-01T00:00:00",
-        "-01-07T00:00:00",
-        "-02-12T00:00:00",
-        "-02-17T00:00:00",
-        "-03-22T00:00:00",
-        "-03-28T00:00:00",
-    };
+    // Declare the supported options.
+    opts::positional_options_description p;
+    opts::variables_map vm;
+    opts::options_description desc("Allowed options");
+    desc.add_options()
+        ("timestamp,t", opts::value<std::vector<std::string>>(), "Starting timestamp")
+    ;
+    opts::store(opts::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+    opts::notify(vm);
 
-    ptime now = boost::posix_time::microsec_clock::universal_time();
-    int next_year = now.date().year() + 1;
+    if (vm.count("timestamp")) {
+        auto timestamps = vm["timestamp"].as<std::vector<std::string>>();
+        config.start_time = from_iso_extended_string(timestamps[0]);
+        testPath(config);
+    } else {
+        std::vector<std::string> dates = {
+            "-01-01T00:00:00",
+            "-03-07T00:00:00",
+            "-06-12T00:00:00",
+            "-08-17T00:00:00",
+            "-10-22T00:00:00",
+            "-12-28T00:00:00",
+        };
 
-    for (int i = 2017; i != next_year; ++i) {
-        for (auto it = std::begin(dates); it != std::end(dates); ++it) {
+        ptime now = boost::posix_time::microsec_clock::universal_time();
+        int next_year = now.date().year() + 1;
 
-            std::string year_string = std::to_string(i);
-            std::string ts(year_string + *it);
-            config.start_time = from_iso_extended_string(ts);
+        for (int i = 2017; i != next_year; ++i) {
+            for (auto it = std::begin(dates); it != std::end(dates); ++it) {
 
-            time_duration diffWithNow = now - config.start_time;
+                std::string year_string = std::to_string(i);
+                std::string ts(year_string + *it);
+                config.start_time = from_iso_extended_string(ts);
 
-            if (diffWithNow.hours() > 0) {
+                time_duration diffWithNow = now - config.start_time;
 
-                planetreplicator::PlanetReplicator replicator;
-                auto osmchange = replicator.findRemotePath(config, config.start_time);
-                TestCO change;
-                if (boost::filesystem::exists(osmchange->filespec)) {
-                    change.readChanges(osmchange->filespec);
-                } else { 
-                    TestPlanet planet;
-                    auto data = planet.downloadFile(osmchange->getURL());
-                    auto xml = planet.processData(osmchange->filespec, *data);
-                    std::istream& input(xml);
-                    change.readXML(input);
-                }
-
-                ptime timestamp = change.changes.back()->final_entry;
-                auto timestamp_string = to_simple_string(timestamp);
-                auto start_time_string = to_simple_string(config.start_time);
-
-                time_duration delta = timestamp - config.start_time;
-                if (delta.hours() > -24 && delta.hours() < 12) {
-                    runtest.pass("Find remote path from timestamp +/- 1 day (" + start_time_string + ") (" + timestamp_string + ")");
-                } else {
-                    runtest.fail("Find remote path from timestamp +/- 1 day (" + start_time_string + ") (" + timestamp_string + ")");
+                if (diffWithNow.hours() > 0) {
+                    testPath(config);
                 }
             }
         }


### PR DESCRIPTION
In this PR I added the path for /005 directory in PlanetReplicator class and did improvements for the PlanetReplicator::findRemotePath() test, now it accepts a parameter for timestamp or generate dates automatically as default. This is mostly for issue #161. 

A new test for tracking all changesets ids inside a changeset file was also added (issue #166)