### PR TITLE
Synchronize osmchanges and changesets indexes when replication proces…

### DIFF
--- a/galaxy/replication.cc
+++ b/galaxy/replication.cc
@@ -639,9 +639,9 @@ RemoteURL::updatePath(int _major, int _minor, int _index)
     boost::format minorfmt("%03d");
     boost::format indexfmt("%03d");
 
-    // major = _major;
-    // minor = _minor;
-    // index = _index;
+    major = _major;
+    minor = _minor;
+    index = _index;
 
     majorfmt % (_major);
     minorfmt % (_minor);

--- a/replicator.cc
+++ b/replicator.cc
@@ -345,20 +345,21 @@ main(int argc, char *argv[])
             boost::algorithm::replace_all(osmchange->filespec, ".state.txt", ".osc.gz");
         }
 
-        // osmchange->dump();
-        std::thread oscthr(threads::startMonitorChanges, std::ref(osmchange),
+        // OsmChanges thread
+        std::thread osmChangesThread(threads::startMonitorChanges, std::ref(osmchange),
                            std::ref(geou.boundary), std::ref(config));
-        config.frequency = replication::changeset;
-        auto changeset = replicator.findRemotePath(config, config.start_time);
-        // changeset->dump();
 
         // Changesets thread
-        std::thread osmthr(threads::startMonitorChangesets, std::ref(changeset),
-                           std::ref(geou.boundary), std::ref(config));
+        config.frequency = replication::changeset;
+        auto changeset = replicator.findRemotePath(config, config.start_time);
+        changeset->updatePath(osmchange->major, osmchange->minor, osmchange->index);
+        std::thread changesetsThread(threads::startMonitorChangesets, std::ref(changeset),
+                                    std::ref(geou.boundary), std::ref(config));
+        
         log_info(_("Waiting..."));
 
-        oscthr.join();
-        osmthr.join();
+        changesetsThread.join();
+        osmChangesThread.join();
         exit(0);
     }
 


### PR DESCRIPTION
Changeset path gets updated before running the monitoring thread. I had to uncomment 3 lines from updatePath() so minor, major and index gets updated. 