### PR TITLE
Test scripts for compare statistics between underpass and insights

### DIFF
--- a/galaxy/replication.cc
+++ b/galaxy/replication.cc
@@ -751,7 +751,7 @@ RemoteURL::RemoteURL(const RemoteURL &inr)
 void
 RemoteURL::dump(void)
 {
-    std::cout << "\t------" << std::endl;
+    std::cerr << "\t------" << std::endl;
     std::cerr << "\tDomain: " << domain << std::endl;
     std::cerr << "\tDatadir: " << datadir << std::endl;
     std::cerr << "\tSubpath: " << subpath << std::endl;

--- a/testsuite/libunderpass.all/stats-test.cc
+++ b/testsuite/libunderpass.all/stats-test.cc
@@ -20,19 +20,121 @@
 #include <dejagnu.h>
 #include "galaxy/osmchange.hh"
 #include <boost/geometry.hpp>
+#include <boost/program_options.hpp>
+#include "data/geoutil.hh"
 #include <iostream>
 #include "log.hh"
+#include "replicatorconfig.hh"
+#include "galaxy/planetreplicator.hh"
 
+namespace opts = boost::program_options;
+
+using namespace replicatorconfig;
+using namespace planetreplicator;
 using namespace logger;
 
 class TestOsmChanges : public osmchange::OsmChangeFile {
 };
 
-TestState runtest;
+class TestCO : public osmchange::OsmChangeFile {
+};
 
-int
-main(int argc, char *argv[]) {
+class TestPlanet : public replication::Planet {
+};
 
+void
+collectStats(opts::variables_map vm) {
+
+    ReplicatorConfig config;    
+    if (vm.count("timestamp")) {
+        auto timestamp = vm["timestamp"].as<std::string>();
+        config.start_time = from_iso_extended_string(timestamp);
+    } else {
+        config.start_time = from_iso_extended_string("2022-01-01T00:00:00");
+    }
+    config.planet_server = config.planet_servers[0].domain + "/replication";
+    std::string boundary = "priority.geojson";
+    if (vm.count("boundary")) {
+        boundary = vm["boundary"].as<std::string>();
+    }
+    geoutil::GeoUtil geou;
+    multipolygon_t poly;
+    if (!geou.readFile(boundary)) {
+        log_debug(_("Could not find '%1%' area file!"), boundary);
+        boost::geometry::read_wkt("MULTIPOLYGON(((-180 90,180 90, 180 -90, -180 -90,-180 90)))", poly);
+    } else {
+        poly = geou.boundary;
+    }
+ 
+    int increment;
+    if (vm.count("increment")) {
+        const auto str_increment = vm["increment"].as<std::string>();
+        increment = std::stoi(str_increment) + 1;
+    } else { 
+        increment = 2;
+    }
+    planetreplicator::PlanetReplicator replicator;
+    auto osmchange = replicator.findRemotePath(config, config.start_time);
+    
+    std::string jsonstr = "[";
+
+    while (--increment) {
+        TestCO change;
+        if (boost::filesystem::exists(osmchange->filespec)) {
+            change.readChanges(osmchange->filespec);
+        } else { 
+            TestPlanet planet;
+            auto data = planet.downloadFile(osmchange->getURL());
+            auto xml = planet.processData(osmchange->filespec, *data);
+            std::istream& input(xml);
+            change.readXML(input);
+        }
+        change.areaFilter(poly);
+        auto stats = change.collectStats(poly);
+
+        for (auto it = std::begin(*stats); it != std::end(*stats); ++it) {
+            auto changestats = it->second;
+            jsonstr += "{\"changeset_id\":" + std::to_string(changestats->change_id);
+
+            if (changestats->added.size() > 0) {
+                jsonstr += ", \"added\":[";
+                for (const auto &added: std::as_const(changestats->added)) {
+                    if (added.second > 0) {
+                        jsonstr += "{\"" + added.first + "\":" + std::to_string(added.second) + "},";
+                    }
+                }
+                jsonstr.erase(jsonstr.size() - 1);
+                jsonstr += "]";
+            } else {
+                jsonstr += ", \"added\": []";
+            }
+
+            if (changestats->modified.size() > 0) {
+                jsonstr += ", \"modified\":[";
+                for (const auto &modified: std::as_const(changestats->modified)) {
+                    if (modified.second > 0) {
+                        jsonstr += "{\"" + modified.first + "\":" + std::to_string(modified.second) + "},";
+                    }
+                }
+                jsonstr.erase(jsonstr.size() - 1);
+                jsonstr += "]},\n";
+            } else {
+                jsonstr += ", \"modified\": []},\n";
+            }
+
+        }
+
+        osmchange->Increment();
+    }
+
+    jsonstr.erase(jsonstr.size() - 2);
+    jsonstr += "\n]";
+    std::cout << jsonstr << std::endl;
+
+}
+
+void runTests() {
+    TestState runtest;
     logger::LogFile &dbglogfile = logger::LogFile::getDefaultInstance();
     dbglogfile.setWriteDisk(true);
     dbglogfile.setLogFilename("stats-test.log");
@@ -84,7 +186,30 @@ main(int argc, char *argv[]) {
     } else {
         runtest.fail("Calculating modified waterways");
     }   
+}
 
+int
+main(int argc, char *argv[]) {
+    // Declare the supported options.
+    opts::positional_options_description p;
+    opts::variables_map vm;
+    opts::options_description desc("Allowed options");
+    desc.add_options()
+        ("mode,m", opts::value<std::string>(), "Mode (collect-stats)")
+        ("timestamp,t", opts::value<std::string>(), "Starting timestamp (default: 2022-01-01T00:00:00)")
+        ("increment,i", opts::value<std::string>(), "Number of increments to do (default: 1)")
+        ("boundary,b", opts::value<std::string>(), "Boundary polygon file name");
+
+    opts::store(opts::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+    opts::notify(vm);
+
+    if (vm.count("mode")) {
+        if (vm["mode"].as<std::string>() == "collect-stats") {
+            collectStats(vm);
+        }
+    } else {
+        runTests();
+    }
 
 }
 

--- a/util/insights.py
+++ b/util/insights.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2020, 2021 Humanitarian OpenStreetMap Team
+#
+# This file is part of Underpass.
+#
+#     Underpass is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     Underpass is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with Underpass.  If not, see <https://www.gnu.org/licenses/>.
+
+import psycopg2
+from urllib.parse import urlparse
+from sys import argv
+from progress.spinner import PixelSpinner
+import json
+
+def usage():
+    out = """
+    Usage:
+
+    python insights.py <db_connection_string> <stats_json_file>
+    """
+    print(out)
+    quit()
+
+if len(argv) <= 1:
+    usage()
+
+database = argv[1]
+json_file = argv[2]
+
+class InsightsConnection:
+    def __init__(self):
+        conn = urlparse(database)
+        
+        self.dbshell = psycopg2.connect(
+            database = conn.hostname,
+            user = conn.username,
+            password = conn.password,
+            port = conn.port,
+            host = conn.scheme
+        )
+        self.dbshell.autocommit = True
+        self.dbcursor = self.dbshell.cursor()
+
+    def getChangesetsStats(self, changesetId):
+        query = """SELECT changeset, added_buildings, modified_buildings, added_amenity, \
+                added_highway, modified_highway, added_highway_meters, \
+                added_places, modified_places FROM all_changesets_stats WHERE changeset = %s""" \
+                % changesetId
+        self.dbcursor.execute(query)
+        changeset = self.dbcursor.fetchone()
+        if changeset:
+            return {
+                'changeset': changeset[0] or 0,
+                'added_buildings': changeset[1] or 0,
+                'modified_buildings': changeset[2] or 0,
+                'added_amenity': changeset[3] or 0,
+                'added_highway': changeset[4] or 0,
+                'modified_highway': changeset[5] or 0,
+                'added_highway_km': round(changeset[6] or 0) ,
+                'added_places': changeset[7] or 0,
+                'modified_places': changeset[8] or 0
+            }
+        else:
+            return None
+
+
+class UnderpassStats:
+    def __init__(self):
+        pass
+
+    def readJSON(self, json_file):
+        f = open(json_file)
+        dataFromFile = json.load(f)
+        data = []
+        for row in dataFromFile:
+            existingItemIndex = next((i for i, item in enumerate(data) if item["changeset"] == row['changeset_id']), None)
+            if existingItemIndex == None:
+                data.append({
+                    'changeset': row['changeset_id'],
+                    'added_buildings': self.getValue(row, 'added','building'),
+                    'modified_buildings': self.getValue(row, 'modified','building'),
+                    'added_amenity': self.getValue(row, 'added','amenity'),
+                    'added_highway': self.getValue(row, 'added','highway'),
+                    'modified_highway': self.getValue(row, 'modified','highway'),
+                    'added_highway_km': self.getValue(row, 'added','highway_km'),
+                    'added_places': self.getValue(row, 'added','places'),
+                    'modified_places': self.getValue(row, 'modified','places'),
+                })
+            else:
+                data[existingItemIndex]['added_buildings'] += self.getValue(row, 'added','building')
+                data[existingItemIndex]['modified_buildings'] += self.getValue(row, 'modified','building')
+                data[existingItemIndex]['added_amenity'] += self.getValue(row, 'added','amenity')
+                data[existingItemIndex]['added_highway'] += self.getValue(row, 'added','highway')
+                data[existingItemIndex]['modified_highway'] += self.getValue(row, 'modified','highway')
+                data[existingItemIndex]['added_highway_km'] += self.getValue(row, 'added','highway_km')
+                data[existingItemIndex]['added_places'] += self.getValue(row, 'added','places')
+                data[existingItemIndex]['modified_places'] += self.getValue(row, 'modified','places')
+        
+        return data
+
+    def getValue(self, row, column, label):
+        for value in row[column]:
+            if label in value:
+                return value[label]
+        return 0
+
+bar = PixelSpinner('Reading Underpass stats ... ')
+underpassStats = UnderpassStats()
+stats = underpassStats.readJSON(json_file)
+
+bar = PixelSpinner('Connecting ... ')
+insightsDB = InsightsConnection()
+bar = PixelSpinner('Getting data ... ')
+
+insightsCount = 0
+badStatsCount = 0
+notFound = []
+for stat in stats:
+    insights = insightsDB.getChangesetsStats(stat['changeset'])
+    if insights is not None:
+        insightsCount += 1
+        if insights != stat:
+            badStatsCount += 1
+            bad_stat = {'changeset': stat['changeset']}
+            for value in insights:
+                if insights[value] != stat[value]:
+                    bad_stat['stats_' + str(value)] = stat[value]
+                    bad_stat['insights__' + str(value)] = insights[value]
+            print(bad_stat)
+    else:
+        notFound.append(stat['changeset'])
+
+print("\n---------")
+print(len(notFound), "changesets not found in Insights DB")
+print(badStatsCount, "/", insightsCount, "are not equal (", badStatsCount * 100 / insightsCount, "%)")


### PR DESCRIPTION
### Comparing statistics between Underpass and Insights

**1. Run `stats-test` in collect-stats mode, passing timestamp and increment (optional) arguments and save the results into a JSON file**

`./testsuite/libunderpass.all/stats-test -m collect-stats -i 10 -t 2020-Oct-21T00:00:00 > stats-results.json`

**2. Run the `insights.py` script on the JSON file to get a statistics comparison (you'll need a virtualenv with pip packages installed on it, check requirements.txt)** 

`python insights.py <DB_CONNECTION_STRING> test-stats.json > test-stats-report.txt`

The DB connection string using SSH port forwarding will look like this:

`localhost://<username>:<password>@<database>:<local_port>`

**3. After running the Python script, a report will be created:**

```
{'changeset': 92747671, 'stats_added_highway': 5, 'insights__added_highway': 9, 'stats_modified_highway': 6, 'insights__modified_highway': 7, 'stats_added_highway_km': 16664672, 'insights__added_highway_km': 1698}
{'changeset': 92747674, 'stats_added_buildings': 2, 'insights__added_buildings': 1, 'stats_added_amenity': 0, 'insights__added_amenity': 1}
{'changeset': 92747677, 'stats_added_highway_km': 7270846, 'insights__added_highway_km': 1217}
{'changeset': 92747678, 'stats_added_highway_km': 7951980, 'insights__added_highway_km': 179}
{'changeset': 92747691, 'stats_added_highway_km': 34103161, 'insights__added_highway_km': 3034}
...
---------
285 changesets not found in Insights DB
73 / 167 are not equal ( 43.712574850299404 %)
```

Each row has the changeset ID and the stats that are different between Underpass and Insights. For example, in the changeset 92747674 Underpass counted 2 buildings added and 0 amenities. While Insights had 1 building added and 1 amenity:

`{'changeset': 92747674, 'stats_added_buildings': 2, 'insights__added_buildings': 1, 'stats_added_amenity': 0, 'insights__added_amenity': 1}`

This can happen for several reasons that will be discussed later, using these tools for comparing statistics.

### General view of the process

<img width="972" alt="Screen Shot 2022-04-29 at 11 49 53" src="https://user-images.githubusercontent.com/1226194/165971427-4bd2056f-9288-454b-9bf1-ff12f1f50b14.png">

