### PR TITLE
Fix/replicator keep running

### DIFF
--- a/data/threads.cc
+++ b/data/threads.cc
@@ -173,8 +173,8 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
     );
     remote->Decrement();
     std::cout << "Caught up with: " << remote->filespec << std::endl;
-    auto delay = std::chrono::minutes{1};
-    std::this_thread::sleep_for(delay);
+    std::this_thread::sleep_for(std::chrono::minutes{1});
+    auto delay = std::chrono::seconds{30};
     osm_not_found = false;
     while (mainloop) {
         std::rotate(galaxies.begin(), galaxies.begin()+1, galaxies.end());
@@ -291,9 +291,8 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
     );
     remote->Decrement();
     std::cout << "Caught up with: " << remote->filespec << std::endl;
-    auto delay = std::chrono::minutes{1};
-    std::this_thread::sleep_for(delay);
-    osc_not_found = false;
+    std::this_thread::sleep_for(std::chrono::minutes{1});
+    auto delay = std::chrono::seconds{30};
     while (mainloop) {
         std::rotate(galaxies.begin(), galaxies.begin()+1, galaxies.end());
         std::rotate(planets.begin(), planets.begin()+1, planets.end());
@@ -332,7 +331,7 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
         osc_not_found = true;
         osc_subpath = remote->subpath;
         return osmchanges;
-    } else {
+    } else {        
         try {
             std::istringstream changes_xml;
             // Scope to deallocate buffers
@@ -347,7 +346,7 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 
             try {
                 osmchanges->readXML(changes_xml);
-
+                osc_not_found = false;
             } catch (std::exception &e) {
                 log_error(_("Couldn't parse: %1%"), remote->filespec);
                 std::cerr << e.what() << std::endl;
@@ -457,6 +456,7 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
 	auto xml = planet->processData(remote->filespec, *data);
 	std::istream& input(xml);
 	changeset->readXML(input);
+    osm_not_found = false;
     }
 
    changeset->areaFilter(poly);

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -174,12 +174,10 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
     remote->Decrement();
     std::cout << "Caught up with: " << remote->filespec << std::endl;
     std::this_thread::sleep_for(std::chrono::minutes{1});
-    auto delay = std::chrono::seconds{30};
-    osm_not_found = false;
+    auto delay = std::chrono::seconds{45};
     while (mainloop) {
         std::rotate(galaxies.begin(), galaxies.begin()+1, galaxies.end());
         std::rotate(planets.begin(), planets.begin()+1, planets.end());
-        // std::cout << "Caught up with: " << remote.filespec << std::endl;
         threadChangeSet(std::ref(remote),
                 std::ref(planets.front()),
                 std::ref(poly),
@@ -292,7 +290,7 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
     remote->Decrement();
     std::cout << "Caught up with: " << remote->filespec << std::endl;
     std::this_thread::sleep_for(std::chrono::minutes{1});
-    auto delay = std::chrono::seconds{30};
+    auto delay = std::chrono::seconds{45};
     while (mainloop) {
         std::rotate(galaxies.begin(), galaxies.begin()+1, galaxies.end());
         std::rotate(planets.begin(), planets.begin()+1, planets.end());

--- a/data/threads.hh
+++ b/data/threads.hh
@@ -84,6 +84,9 @@ typedef std::shared_ptr<Validate>(plugin_t)();
 /// \namespace threads
 namespace threads {
 
+// std::pair<ptime, std::string>
+// getClosestProcessedChange(std::shared_ptr<std::vector<std::pair<ptime, std::string>>> processed, ptime now);
+
 /// This monitors the planet server for new changesets files.
 /// It does a bulk download to catch up the database, then checks for the
 /// minutely change files and processes them.
@@ -102,23 +105,24 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
 
 /// Updates the raw_hashtags, raw_users, and raw_changesets_countries tables
 /// from a changeset file
-extern std::shared_ptr<osmchange::OsmChangeFile>
-threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
+void threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<replication::Planet> &planet,
-                const multipolygon_t &poly,
+		const multipolygon_t &poly,
 		std::shared_ptr<galaxy::QueryGalaxy> &galaxy,
-                std::shared_ptr<osm2pgsql::Osm2Pgsql> &rawosm,
-                std::shared_ptr<Validate> &plugin,
-		std::shared_ptr<std::vector<long>> removals);
+		std::shared_ptr<osm2pgsql::Osm2Pgsql> &rawosm,
+		std::shared_ptr<Validate> &plugin,
+		std::shared_ptr<std::vector<long>> removals,
+		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
 
 /// This updates several fields in the raw_changesets table, which are part of
 /// the changeset file, and don't need to be calculated.
 // extern bool threadChangeSet(const std::string &file);
-extern std::unique_ptr<changeset::ChangeSetFile>
+void
 threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<replication::Planet> &planet,
                 const multipolygon_t &poly,
-		std::shared_ptr<galaxy::QueryGalaxy> galaxy);
+		std::shared_ptr<galaxy::QueryGalaxy> galaxy,
+		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
 
 // extern bool threadChangeSet(const std::string &file, std::promise<bool> && result);
 

--- a/galaxy/planetreplicator.cc
+++ b/galaxy/planetreplicator.cc
@@ -122,9 +122,9 @@ PlanetReplicator::PlanetReplicator(void) {
     StateFile state4("/004/000/000", 4000000, time4, replication::minutely);
     default_minutes.push_back(state4);
 
-    // ptime time5 = time_from_string("2022-04-03 16:25:35");
-    // StateFile state5("/005/000/000", 5000000, time5, replication::minutely);
-    // default_minutes.push_back(state5);
+    ptime time5 = time_from_string("2022-04-03 16:25:35");
+    StateFile state5("/005/000/000", 5000000, time5, replication::minutely);
+    default_minutes.push_back(state5);
 
     // Changesets
     ptime time11 = time_from_string("2012-10-28 19:36:01");
@@ -146,10 +146,6 @@ PlanetReplicator::PlanetReplicator(void) {
     ptime time7 = time_from_string("2020-06-28 23:26:01");
     StateFile state7("/004/000/000", 3000000, time7, replication::changeset);
     default_changesets.push_back(state7);
-
-    ptime time6 = time_from_string("2022-04-03 16:25:35");
-    StateFile state6("/005/000/000", 3000000, time6, replication::changeset);
-    default_changesets.push_back(state6);
 };
 
 /// Initialize the raw_user, raw_hashtags, and raw_changeset tables
@@ -298,7 +294,9 @@ std::shared_ptr<RemoteURL> PlanetReplicator::findRemotePath(const replicatorconf
             change.readXML(input);
         }
         // change.dump();
-        timestamp = change.changes.back()->created_at;
+        if (change.changes.size() > 0) {
+            timestamp = change.changes.back()->created_at;
+        }
     }
 
     // remote->dump();

--- a/replicator.cc
+++ b/replicator.cc
@@ -352,7 +352,6 @@ main(int argc, char *argv[])
         // Changesets thread
         config.frequency = replication::changeset;
         auto changeset = replicator.findRemotePath(config, config.start_time);
-        changeset->updatePath(osmchange->major, osmchange->minor, osmchange->index);
         std::thread changesetsThread(threads::startMonitorChangesets, std::ref(changeset),
                                     std::ref(geou.boundary), std::ref(config));
         


### PR DESCRIPTION
### Keep replicator running 

Now there's a local vector _tasks_ that keeps track of the processed threads . Tasks are being pushed to the vector including the _subpath_ string and _not_a_date_time_ for the _timestamp_ value. When the change is downloaded and processed,  timestamp is updated. If something fails, timestamp will remains _not_a_date_time_.

When a pool of tasks finished, the process looks for the closest change and if it's 2 minutes to current time, it will change to single threading instead of multiple, with a delay of 45 seconds between threads instead of no delay. This delay is below 1 minute so the process can keep the pace, providing data in almost real-time.

Logic is the same for both Changesets and OsmChanges.

#### Note about syncing

Path for 005 was restored for OsmChanges and removed for Changesets, because is not available for the last one yet. Also, when replicator starts, I removed the path updating  for changesets (this was a mistake because I wrongly understood that both changes had the same paths)