### PR TITLE
Improve API container setup and config file

### DIFF
--- a/infra/config.txt.tftpl
+++ b/infra/config.txt.tftpl
@@ -12,7 +12,7 @@ port=${api_port}
 
 ; OAuth2 Credentials for OSM.org login
 [OAUTH]
-%{ for k, v in oauth2_creds }
+%{ for k, v in oauth2_creds ~}
 ${k}=${v}
 %{ endfor ~}
 url=https://www.openstreetmap.org
@@ -28,25 +28,25 @@ osmstats=osmstats.sql
 
 ; Insights database access credentials
 [INSIGHTS]
-%{ for k, v in insights_creds }
+%{ for k, v in insights_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
 ; Underpass database access credentials
 [UNDERPASS]
-%{ for k, v in underpass_creds }
+%{ for k, v in underpass_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
 ; Tasking Manager database access credentials
 ; TODO: Rename section title
 [TM]
-%{ for k, v in tasking_manager_creds }
+%{ for k, v in tasking_manager_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
 [SENTRY]
-url=https://${sentry_api_key}.ingest.sentry.io/${sentry_app_id}
+url=${sentry_dsn}
 rate=1.0
 
 ; If API and UI are on different hosts

--- a/infra/galaxy-api.tf
+++ b/infra/galaxy-api.tf
@@ -135,6 +135,12 @@ resource "aws_ecs_task_definition" "galaxy-api" {
     cpu_architecture        = "X86_64" // or ARM64
   }
 
+  ephemeral_storage {
+    size_in_gib = 200
+  }
+
+  execution_role_arn = aws_iam_role.ecs_execution_role.arn
+
   container_definitions = jsonencode([
     {
       name  = "galaxy-api"
@@ -180,7 +186,7 @@ resource "aws_ecs_task_definition" "galaxy-api" {
       ]
     }
   ])
-  execution_role_arn = aws_iam_role.ecs_execution_role.arn
+
 }
 
 resource "aws_ecs_service" "galaxy-api" {
@@ -383,7 +389,7 @@ resource "aws_secretsmanager_secret" "configfile" {
 
 resource "aws_secretsmanager_secret_version" "configfile" {
   secret_id = aws_secretsmanager_secret.configfile.id
-  secret_string = base64gzip(
+  secret_string = base64encode(
     templatefile(
       "${path.module}/config.txt.tftpl",
       {
@@ -395,11 +401,10 @@ resource "aws_secretsmanager_secret_version" "configfile" {
 
         oauth2_creds = var.oauth2_credentials
 
-        api_url        = "${var.api_url_scheme}${var.api_host}"
-        api_port       = var.api_port
+        api_url  = "${var.api_url_scheme}${var.api_host}"
+        api_port = var.api_port
 
-        sentry_api_key = var.sentry_api_key
-        sentry_app_id  = var.sentry_galaxy_api_app_id
+        sentry_dsn = var.sentry_dsn
       }
     )
   )

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -208,12 +208,7 @@ variable "api_url_scheme" {
   default = "https://"
 }
 
-variable "sentry_api_key" {
-  type = string
-  default = ""
-}
-
-variable "sentry_galaxy_api_app_id" {
+variable "sentry_dsn" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
- Add 200 GiB ephemeral storage to containers
- Do not GZip config file before storing to Secrets Manager
- Proper nomenclature for Sentry DSN
- Remove extraneous newlines from API config file