### PR TITLE
Fix/threads

### DIFF
--- a/data/threads.cc
+++ b/data/threads.cc
@@ -181,20 +181,25 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
         pool.join();
         
         ptime now  = boost::posix_time::second_clock::universal_time();
-        closest = getClosest(tasks, now);
-        // Check if caught up with now
-        if (cores > 1) {
-            boost::posix_time::time_duration delta_closest = now - closest->second;
-            if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
-                log_debug(_("Caught up with: %1%"), closest->first);
-                remote->updatePath(
-                    std::stoi(closest->first.substr(0, 3)),
-                    std::stoi(closest->first.substr(4, 3)),
-                    std::stoi(closest->first.substr(8, 3))
-                );
-                cores = 1;
-                delay = std::chrono::seconds{45};        
+        if (tasks->size() > 0 && cores > 1) {
+            closest = getClosest(tasks, now);
+            // Check if caught up with now
+            if (cores > 1) {
+                boost::posix_time::time_duration delta_closest = now - closest->second;
+                if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
+                    log_debug(_("Caught up with: %1%"), closest->first);
+                    remote->updatePath(
+                        std::stoi(closest->first.substr(0, 3)),
+                        std::stoi(closest->first.substr(4, 3)),
+                        std::stoi(closest->first.substr(8, 3))
+                    );
+                    cores = 1;
+                    delay = std::chrono::seconds{45};        
+                }
             }
+        } else if (cores > 1) {
+            cores = 1;
+            delay = std::chrono::seconds{45};        
         }
     }
 }
@@ -297,7 +302,7 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
         ptime now  = boost::posix_time::second_clock::universal_time();
         closest = getClosest(tasks, now);
         // Check if caught up with now
-        if (cores > 1) {
+        if (tasks->size() > 0 && cores > 1) {
             boost::posix_time::time_duration delta_closest = now - closest->second;
             if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
                 log_debug(_("Caught up with: %1%"), closest->first);
@@ -309,6 +314,9 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
                 cores = 1;
                 delay = std::chrono::seconds{45};        
             }
+        } else if (cores > 1) {
+            cores = 1;
+            delay = std::chrono::seconds{45};                    
         }
     }
 }

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -456,12 +456,12 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
         auto xml = planet->processData(remote->filespec, *data);
         std::istream& input(xml);
         changeset->readXML(input);
-        log_debug(_("ChangeSet last_closed_at: %1%"), task.second);
         changeset->areaFilter(poly);
         for (auto cit = std::begin(changeset->changes); cit != std::end(changeset->changes); ++cit) {
             galaxy->applyChange(*cit->get());
         }
         task.second = changeset->last_closed_at;
+        log_debug(_("ChangeSet last_closed_at: %1%"), task.second);
     }
     const std::lock_guard<std::mutex> lock(tasks_changeset_mutex);
     tasks->push_back(task);

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -109,6 +109,9 @@ getClosest(std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks, pt
             }
         }
     }
+    if (closest.second == not_a_date_time) {
+        closest.second = now;
+    }
     return std::make_shared<std::pair<std::string, ptime>>(closest);
 }
 
@@ -349,6 +352,7 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
             try {
                 osmchanges->readXML(changes_xml);  
                 task.second = osmchanges->changes.back()->final_entry;
+                log_debug(_("OsmChange final_entry: %1%"), task.second);
             } catch (std::exception &e) {
                 log_error(_("Couldn't parse: %1%"), remote->filespec);
                 std::cerr << e.what() << std::endl;
@@ -446,6 +450,7 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
         std::istream& input(xml);
         changeset->readXML(input);
         task.second = changeset->last_closed_at;
+        log_debug(_("ChangeSet last_closed_at: %1%"), task.second);
         changeset->areaFilter(poly);
         for (auto cit = std::begin(changeset->changes); cit != std::end(changeset->changes); ++cit) {
             galaxy->applyChange(*cit->get());

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -97,19 +97,19 @@ std::mutex tasks_change_mutex;
 std::mutex tasks_changeset_mutex;
 
 // Get closest change from a list of tasks
-std::shared_ptr<std::pair<std::string, ptime>> 
-getClosest(std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks, ptime now) {
+std::shared_ptr<ReplicationTask> 
+getClosest(std::shared_ptr<std::vector<ReplicationTask>> tasks, ptime now) {
     auto closest = tasks->at(0);
     for (auto it = tasks->begin(); it != tasks->end(); ++it) {
-        if (it->second != not_a_date_time) {
-            boost::posix_time::time_duration delta = now - it->second;
-            boost::posix_time::time_duration delta_oldest = now - closest.second;
+        if (it->timestamp != not_a_date_time) {
+            boost::posix_time::time_duration delta = now - it->timestamp;
+            boost::posix_time::time_duration delta_oldest = now - closest.timestamp;
             if (delta.hours() * 60 + delta.minutes() < delta_oldest.hours() * 60 + delta_oldest.minutes()) {
                 closest = *it;
             }
         }
     }
-    return std::make_shared<std::pair<std::string, ptime>>(closest);
+    return std::make_shared<ReplicationTask>(closest);
 }
 
 // Starting with this URL, download the file, incrementing
@@ -153,15 +153,15 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
 
     bool mainloop = true;
     auto delay = std::chrono::seconds{0};
-    auto closest = std::pair<std::string, ptime>();
-    auto last_task = std::make_shared<std::pair<std::string, ptime>>();
+    ReplicationTask closest;
+    auto last_task = std::make_shared<ReplicationTask>();
     while (mainloop) {
-        auto tasks = std::make_shared<std::vector<std::pair<std::string, ptime>>>();
+        auto tasks = std::make_shared<std::vector<ReplicationTask>>();
         i = cores*2;
-        boost::asio::thread_pool pool(i-1);
+        boost::asio::thread_pool pool(i);
         while (--i) {
             std::this_thread::sleep_for(delay);
-            if (last_task->second != not_a_date_time) {
+            if (last_task->processed) {
                 remote->Increment();
             }
             auto task = boost::bind(threadChangeSet,
@@ -180,19 +180,20 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
         
         ptime now  = boost::posix_time::second_clock::universal_time();
         last_task = getClosest(tasks, now);
+        log_debug(_("last_task: %1%"), last_task->timestamp);
         if (cores > 1) {
             // Check if caught up with now
-            if (last_task->second != not_a_date_time) {
-                closest.first = std::string(last_task->first);
-                closest.second = ptime(last_task->second);
+            if (last_task->timestamp != not_a_date_time) {
+                closest.url = std::string(last_task->url);
+                closest.timestamp = ptime(last_task->timestamp);
             }
-            boost::posix_time::time_duration delta_closest = now - closest.second;
+            boost::posix_time::time_duration delta_closest = now - closest.timestamp;
             if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
-                log_debug(_("Caught up with: %1%"), closest.first);
+                log_debug(_("Caught up with: %1%"), closest.url);
                 remote->updatePath(
-                    std::stoi(closest.first.substr(0, 3)),
-                    std::stoi(closest.first.substr(4, 3)),
-                    std::stoi(closest.first.substr(8, 3))
+                    std::stoi(closest.url.substr(0, 3)),
+                    std::stoi(closest.url.substr(4, 3)),
+                    std::stoi(closest.url.substr(8, 3))
                 );
                 cores = 1;
                 delay = std::chrono::seconds{45};        
@@ -261,15 +262,15 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
     bool mainloop = true;
     auto removals = std::make_shared<std::vector<long>>();
     auto delay = std::chrono::seconds{0};
-    auto closest = std::pair<std::string, ptime>();
-    auto last_task = std::make_shared<std::pair<std::string, ptime>>();
+    ReplicationTask closest;
+    auto last_task = std::make_shared<ReplicationTask>();
     while (mainloop) {
-        auto tasks = std::make_shared<std::vector<std::pair<std::string, ptime>>>();
+        auto tasks = std::make_shared<std::vector<ReplicationTask>>();
         i = cores*2;
-        boost::asio::thread_pool pool(i-1);
+        boost::asio::thread_pool pool(i);
         while (--i) {
             std::this_thread::sleep_for(delay);
-            if (last_task->second != not_a_date_time) {
+            if (last_task->processed) {
                 remote->Increment();
             }
             auto task = boost::bind(threadOsmChange,
@@ -302,17 +303,17 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
         // Check if caught up with now
         // looking on closest date
         if (cores > 1) {
-            if (last_task->second != not_a_date_time) {
-                closest.first = std::string(last_task->first);
-                closest.second = ptime(last_task->second);
+            if (last_task->timestamp != not_a_date_time) {
+                closest.url = std::string(last_task->url);
+                closest.timestamp = ptime(last_task->timestamp);
             }
-            boost::posix_time::time_duration delta_closest = now - closest.second;
+            boost::posix_time::time_duration delta_closest = now - closest.timestamp;
             if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
-                log_debug(_("Caught up with: %1%"), closest.first);
+                log_debug(_("Caught up with: %1%"), closest.url);
                 remote->updatePath(
-                    std::stoi(closest.first.substr(0, 3)),
-                    std::stoi(closest.first.substr(4, 3)),
-                    std::stoi(closest.first.substr(8, 3))
+                    std::stoi(closest.url.substr(0, 3)),
+                    std::stoi(closest.url.substr(4, 3)),
+                    std::stoi(closest.url.substr(8, 3))
                 );
                 cores = 1;
                 delay = std::chrono::seconds{45};        
@@ -330,7 +331,7 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
         std::shared_ptr<osm2pgsql::Osm2Pgsql> &o2pgsql,
 		std::shared_ptr<Validate> &plugin,
 		std::shared_ptr<std::vector<long>> removals,
-        std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks)
+        std::shared_ptr<std::vector<ReplicationTask>> tasks)
 {
     auto osmchanges = std::make_shared<osmchange::OsmChangeFile>();
 #ifdef TIMING_DEBUG
@@ -338,10 +339,10 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 #endif
     log_debug(_("Processing osmChange: %1%"), remote->filespec);
     auto data = planet->downloadFile(*remote.get());
-    auto task = std::pair<std::string, ptime>(
-        remote->subpath,
-        not_a_date_time
-    );
+    ReplicationTask task;
+    task.url = remote->subpath;
+    task.timestamp = not_a_date_time;
+    task.processed = false;
     if (data->size() == 0) {
         log_error(_("osmChange file not found: %1% %2%"), remote->filespec, ".osc.gz");
     } else {        
@@ -359,8 +360,9 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 
             try {
                 osmchanges->readXML(changes_xml);  
-                task.second = osmchanges->changes.back()->final_entry;
-                log_debug(_("OsmChange final_entry: %1%"), task.second);
+                task.processed = true;
+                task.timestamp = osmchanges->changes.back()->final_entry;
+                log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
             } catch (std::exception &e) {
                 log_error(_("Couldn't parse: %1%"), remote->filespec);
                 std::cerr << e.what() << std::endl;
@@ -440,15 +442,15 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<replication::Planet> &planet,
 		const multipolygon_t &poly,
 		std::shared_ptr<galaxy::QueryGalaxy> galaxy,
-        std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks)
+        std::shared_ptr<std::vector<ReplicationTask>> tasks)
 {
 #ifdef TIMING_DEBUG
     boost::timer::auto_cpu_timer timer("threadChangeSet: took %w seconds\n");
 #endif
-    auto task = std::pair<std::string, ptime>(
-        remote->subpath,
-        not_a_date_time
-    );
+    ReplicationTask task;
+    task.url = remote->subpath;
+    task.timestamp = not_a_date_time;
+    task.processed = false;
     auto data = planet->downloadFile(*remote.get());
     if (data->size() > 0) {
         auto changeset = std::make_unique<changeset::ChangeSetFile>();
@@ -456,12 +458,17 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
         auto xml = planet->processData(remote->filespec, *data);
         std::istream& input(xml);
         changeset->readXML(input);
+        task.processed = true;
+        if (changeset->last_closed_at != not_a_date_time) {
+            task.timestamp = changeset->last_closed_at;
+        } else if (changeset->changes.size() && changeset->changes.back()->created_at != not_a_date_time) {
+            task.timestamp = changeset->changes.back()->created_at;
+        }
+        log_debug(_("ChangeSet last_closed_at: %1%"), task.timestamp);
         changeset->areaFilter(poly);
         for (auto cit = std::begin(changeset->changes); cit != std::end(changeset->changes); ++cit) {
             galaxy->applyChange(*cit->get());
         }
-        task.second = changeset->last_closed_at;
-        log_debug(_("ChangeSet last_closed_at: %1%"), task.second);
     }
     const std::lock_guard<std::mutex> lock(tasks_changeset_mutex);
     tasks->push_back(task);

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -157,7 +157,7 @@ startMonitorChangesets(std::shared_ptr<replication::RemoteURL> &remote,
     while (mainloop) {
         i = cores*2;
         boost::asio::thread_pool pool(i);
-        while (i--) {
+        while (--i) {
             std::this_thread::sleep_for(delay);
             if (closest->second != not_a_date_time) {
                 remote->Increment();

--- a/data/threads.hh
+++ b/data/threads.hh
@@ -84,8 +84,12 @@ typedef std::shared_ptr<Validate>(plugin_t)();
 /// \namespace threads
 namespace threads {
 
-// std::pair<ptime, std::string>
-// getClosestProcessedChange(std::shared_ptr<std::vector<std::pair<ptime, std::string>>> processed, ptime now);
+struct ReplicationTask {
+	std::string url;
+	ptime timestamp;
+	bool processed;
+};
+
 
 /// This monitors the planet server for new changesets files.
 /// It does a bulk download to catch up the database, then checks for the
@@ -112,7 +116,7 @@ void threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<osm2pgsql::Osm2Pgsql> &rawosm,
 		std::shared_ptr<Validate> &plugin,
 		std::shared_ptr<std::vector<long>> removals,
-		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
+		std::shared_ptr<std::vector<ReplicationTask>> tasks);
 
 /// This updates several fields in the raw_changesets table, which are part of
 /// the changeset file, and don't need to be calculated.
@@ -122,7 +126,7 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<replication::Planet> &planet,
                 const multipolygon_t &poly,
 		std::shared_ptr<galaxy::QueryGalaxy> galaxy,
-		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
+		std::shared_ptr<std::vector<ReplicationTask>> tasks);
 
 // extern bool threadChangeSet(const std::string &file, std::promise<bool> && result);
 

--- a/galaxy/changeset.cc
+++ b/galaxy/changeset.cc
@@ -405,7 +405,6 @@ void
 ChangeSetFile::on_start_element(const Glib::ustring &name,
                                 const AttributeList &attributes)
 {
-    // log_debug(_("Element %1%"), name);
     if (name == "changeset") {
         auto change = std::make_shared<changeset::ChangeSet>(attributes);
         changes.push_back(change);

--- a/galaxy/changeset.cc
+++ b/galaxy/changeset.cc
@@ -349,7 +349,12 @@ ChangeSetFile::readXML(std::istream &xml)
     // hourly or minutely changes are small, so this is better for that
     // case.
     boost::property_tree::ptree pt;
-    boost::property_tree::read_xml(xml, pt);
+    try {
+        boost::property_tree::read_xml(xml, pt);
+    } catch (exception& boost::property_tree::xml_parser::xml_parser_error) {
+        log_error(_("Error parsing XML"));
+        return false;
+    }
 
     if (pt.empty()) {
         log_error(_("ERROR: XML data is empty!"));

--- a/galaxy/osmchange.cc
+++ b/galaxy/osmchange.cc
@@ -163,12 +163,17 @@ OsmChangeFile::readXML(std::istream &xml)
 #ifdef USE_TMPFILE
     boost::property_tree::read_xml("tmp.xml", pt);
 #else
-    boost::property_tree::read_xml(xml, pt);
+    try {
+        boost::property_tree::read_xml(xml, pt);
+    } catch (exception& boost::property_tree::xml_parser::xml_parser_error) {
+        log_error(_("Error parsing XML"));
+        return false;
+    }
 #endif
 
     if (pt.empty()) {
         log_error(_("ERROR: XML data is empty!"));
-        // return false;
+        return false;
     }
 
     //    boost::progress_display show_progress( 7000 );

--- a/galaxy/planetreplicator.cc
+++ b/galaxy/planetreplicator.cc
@@ -127,25 +127,30 @@ PlanetReplicator::PlanetReplicator(void) {
     default_minutes.push_back(state5);
 
     // Changesets
-    ptime time11 = time_from_string("2012-10-28 19:36:01");
-    StateFile state11("/000/000/000", 3000000, time11, replication::changeset);
-    default_changesets.push_back(state11);
+    ptime time6= time_from_string("2012-10-28 19:36:01");
+    StateFile state6("/000/000/000", 3000000, time6, replication::changeset);
+    default_changesets.push_back(state6);
 
-    ptime time10 = time_from_string("2014-10-07 07:58:01");
-    StateFile state10("/001/000/000", 3000000, time10, replication::changeset);
-    default_changesets.push_back(state10);
+    ptime time7 = time_from_string("2014-10-07 07:58:01");
+    StateFile state7("/001/000/000", 3000000, time7, replication::changeset);
+    default_changesets.push_back(state7);
 
-    ptime time9 = time_from_string("2016-08-01 20:43:01");
-    StateFile state9("/002/000/000", 3000000, time9, replication::changeset);
-    default_changesets.push_back(state9);
-
-    ptime time8 = time_from_string("2018-07-29 16:33:01");
-    StateFile state8("/003/000/000", 3000000, time8, replication::changeset);
+    ptime time8 = time_from_string("2016-08-01 20:43:01");
+    StateFile state8("/002/000/000", 3000000, time8, replication::changeset);
     default_changesets.push_back(state8);
 
-    ptime time7 = time_from_string("2020-06-28 23:26:01");
-    StateFile state7("/004/000/000", 3000000, time7, replication::changeset);
-    default_changesets.push_back(state7);
+    ptime time9 = time_from_string("2018-07-29 16:33:01");
+    StateFile state9("/003/000/000", 3000000, time9, replication::changeset);
+    default_changesets.push_back(state9);
+
+    ptime time10 = time_from_string("2020-06-28 23:26:01");
+    StateFile state10("/004/000/000", 3000000, time10, replication::changeset);
+    default_changesets.push_back(state10);
+
+    ptime time11 = time_from_string("2022-05-30 17:50:02");
+    StateFile state11("/005/000/000", 3000000, time11, replication::changeset);
+    default_changesets.push_back(state11);
+
 };
 
 /// Initialize the raw_user, raw_hashtags, and raw_changeset tables

--- a/replicator.cc
+++ b/replicator.cc
@@ -352,6 +352,7 @@ main(int argc, char *argv[])
         // Changesets thread
         config.frequency = replication::changeset;
         auto changeset = replicator.findRemotePath(config, config.start_time);
+
         std::thread changesetsThread(threads::startMonitorChangesets, std::ref(changeset),
                                     std::ref(geou.boundary), std::ref(config));
         


### PR DESCRIPTION
This PR solves some issues that were happening in the multi-threading replication process.

### Changesets not being processed 

#### created_at and hashtags not available, issue #205

Datetime of last processed task was not available sometimes and this was causing the monitoring thread to stop processing changesets. Now there's a new variable for storing the latest change (`last_task`). This was implemented for OsmChanges also. For changesets , now`last_closed_at` is being used for getting the timestamp of the latest processed.

Update: added a struct (ReplicationTask) for storing processing results.

### Memory issue

The tasks vectors being used in `threads.cc` were causing a crash, randomly. A _mutex_ was added for each of them, before pushing back new items. 

### Added _005_ path for changesets

Changesets path reached _005_ recently. The constructor for `PlanetReplicator` was updated in order to get the correct path when the process starts. Variable names were updated following this change.

### Error catching for XML parsing

This was added to prevent crashes if some file is corrupted.

### Minor fix

A wrong calculation was causing a process to run twice while in waiting mode. 

### Debug info

Added debug messages with timestamps for monitoring.

