### PR TITLE
Fix/threading

### DIFF
--- a/data/threads.cc
+++ b/data/threads.cc
@@ -307,7 +307,7 @@ startMonitorChanges(std::shared_ptr<replication::RemoteURL> &remote,
             }
             boost::posix_time::time_duration delta_closest = now - closest.timestamp;
             if (delta_closest.hours() * 60 + delta_closest.minutes() <= 2) {
-                std::cout << "Caught up with: " << closest->first << std::endl;
+                log_debug(_("Caught up with: %1%"), closest.url);
                 remote->updatePath(
                     std::stoi(closest.url.substr(0, 3)),
                     std::stoi(closest.url.substr(4, 3)),

--- a/data/threads.hh
+++ b/data/threads.hh
@@ -84,8 +84,11 @@ typedef std::shared_ptr<Validate>(plugin_t)();
 /// \namespace threads
 namespace threads {
 
-// std::pair<ptime, std::string>
-// getClosestProcessedChange(std::shared_ptr<std::vector<std::pair<ptime, std::string>>> processed, ptime now);
+struct ReplicationTask {
+	std::string url;
+	ptime timestamp;
+	bool processed;
+};
 
 /// This monitors the planet server for new changesets files.
 /// It does a bulk download to catch up the database, then checks for the

--- a/data/threads.hh
+++ b/data/threads.hh
@@ -115,7 +115,7 @@ void threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<osm2pgsql::Osm2Pgsql> &rawosm,
 		std::shared_ptr<Validate> &plugin,
 		std::shared_ptr<std::vector<long>> removals,
-		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
+		std::shared_ptr<std::vector<ReplicationTask>> tasks);
 
 /// This updates several fields in the raw_changesets table, which are part of
 /// the changeset file, and don't need to be calculated.
@@ -125,7 +125,7 @@ threadChangeSet(std::shared_ptr<replication::RemoteURL> &remote,
 		std::shared_ptr<replication::Planet> &planet,
                 const multipolygon_t &poly,
 		std::shared_ptr<galaxy::QueryGalaxy> galaxy,
-		std::shared_ptr<std::vector<std::pair<std::string, ptime>>> tasks);
+		std::shared_ptr<std::vector<ReplicationTask>> tasks);
 
 // extern bool threadChangeSet(const std::string &file, std::promise<bool> && result);
 

--- a/galaxy/changeset.cc
+++ b/galaxy/changeset.cc
@@ -349,7 +349,12 @@ ChangeSetFile::readXML(std::istream &xml)
     // hourly or minutely changes are small, so this is better for that
     // case.
     boost::property_tree::ptree pt;
-    boost::property_tree::read_xml(xml, pt);
+    try {
+        boost::property_tree::read_xml(xml, pt);
+    } catch (exception& boost::property_tree::xml_parser::xml_parser_error) {
+        log_error(_("Error parsing XML"));
+        return false;
+    }
 
     if (pt.empty()) {
         log_error(_("ERROR: XML data is empty!"));

--- a/galaxy/osmchange.cc
+++ b/galaxy/osmchange.cc
@@ -165,12 +165,17 @@ OsmChangeFile::readXML(std::istream &xml)
 #ifdef USE_TMPFILE
     boost::property_tree::read_xml("tmp.xml", pt);
 #else
-    boost::property_tree::read_xml(xml, pt);
+    try {
+        boost::property_tree::read_xml(xml, pt);
+    } catch (exception& boost::property_tree::xml_parser::xml_parser_error) {
+        log_error(_("Error parsing XML"));
+        return false;
+    }
 #endif
 
     if (pt.empty()) {
         log_error(_("ERROR: XML data is empty!"));
-        // return false;
+        return false;
     }
 
     //    boost::progress_display show_progress( 7000 );

--- a/galaxy/planetreplicator.cc
+++ b/galaxy/planetreplicator.cc
@@ -127,25 +127,29 @@ PlanetReplicator::PlanetReplicator(void) {
     default_minutes.push_back(state5);
 
     // Changesets
-    ptime time11 = time_from_string("2012-10-28 19:36:01");
-    StateFile state11("/000/000/000", 3000000, time11, replication::changeset);
-    default_changesets.push_back(state11);
+    ptime time6= time_from_string("2012-10-28 19:36:01");
+    StateFile state6("/000/000/000", 3000000, time6, replication::changeset);
+    default_changesets.push_back(state6);
 
-    ptime time10 = time_from_string("2014-10-07 07:58:01");
-    StateFile state10("/001/000/000", 3000000, time10, replication::changeset);
-    default_changesets.push_back(state10);
+    ptime time7 = time_from_string("2014-10-07 07:58:01");
+    StateFile state7("/001/000/000", 3000000, time7, replication::changeset);
+    default_changesets.push_back(state7);
 
-    ptime time9 = time_from_string("2016-08-01 20:43:01");
-    StateFile state9("/002/000/000", 3000000, time9, replication::changeset);
-    default_changesets.push_back(state9);
-
-    ptime time8 = time_from_string("2018-07-29 16:33:01");
-    StateFile state8("/003/000/000", 3000000, time8, replication::changeset);
+    ptime time8 = time_from_string("2016-08-01 20:43:01");
+    StateFile state8("/002/000/000", 3000000, time8, replication::changeset);
     default_changesets.push_back(state8);
 
-    ptime time7 = time_from_string("2020-06-28 23:26:01");
-    StateFile state7("/004/000/000", 3000000, time7, replication::changeset);
-    default_changesets.push_back(state7);
+    ptime time9 = time_from_string("2018-07-29 16:33:01");
+    StateFile state9("/003/000/000", 3000000, time9, replication::changeset);
+    default_changesets.push_back(state9);
+
+    ptime time10 = time_from_string("2020-06-28 23:26:01");
+    StateFile state10("/004/000/000", 3000000, time10, replication::changeset);
+    default_changesets.push_back(state10);
+
+    ptime time11 = time_from_string("2022-05-30 17:50:02");
+    StateFile state11("/005/000/000", 3000000, time11, replication::changeset);
+    default_changesets.push_back(state11);
 };
 
 /// Initialize the raw_user, raw_hashtags, and raw_changeset tables


### PR DESCRIPTION
This PR solves some issues that were happening in the multi-threading replication process.

### Changesets not being processed 

#### created_at and hashtags not available, issue #205

Datetime of last processed task was not available sometimes and this was causing the monitoring thread to stop processing changesets. Now there's a new variable for storing the latest change (`last_task`). This was implemented for OsmChanges also. For changesets , now`last_closed_at` is being used for getting the timestamp of the latest processed.

Update: added a struct (ReplicationTask) for storing processing results.

### Memory issue

The tasks vectors being used in `threads.cc` were causing a crash, randomly. A _mutex_ was added for each of them, before pushing back new items. 

### Added _005_ path for changesets

Changesets path reached _005_ recently. The constructor for `PlanetReplicator` was updated in order to get the correct path when the process starts. Variable names were updated following this change.

### Error catching for XML parsing

This was added to prevent crashes if some file is corrupted.

### Minor fix

A wrong calculation was causing a process to run twice while in waiting mode. 

### Debug info

Added debug messages with timestamps for monitoring.

