### PR TITLE
Fix for escape editor string when inserting changeset

### DIFF
--- a/data/threads.cc
+++ b/data/threads.cc
@@ -356,11 +356,16 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
                 changes_xml.str(std::string{std::istreambuf_iterator<char>(instream), {}});
             }
 
-            osmchanges->readXML(changes_xml);
-            task.processed = true;
-            if (osmchanges->changes.size() > 0) {
-                task.timestamp = osmchanges->changes.back()->final_entry;
-                log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
+            try {
+                osmchanges->readXML(changes_xml);  
+                task.processed = true;
+                if (osmchanges->changes.size() > 0) {
+                    task.timestamp = osmchanges->changes.back()->final_entry;
+                    log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
+                }
+            } catch (std::exception &e) {
+                log_error(_("Couldn't parse: %1%"), remote->filespec);
+                std::cerr << e.what() << std::endl;
             }
 
         } catch (std::exception &e) {

--- a/data/threads.cc
+++ b/data/threads.cc
@@ -356,14 +356,11 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
                 changes_xml.str(std::string{std::istreambuf_iterator<char>(instream), {}});
             }
 
-            try {
-                osmchanges->readXML(changes_xml);  
-                task.processed = true;
+            osmchanges->readXML(changes_xml);
+            task.processed = true;
+            if (osmchanges->changes.size() > 0) {
                 task.timestamp = osmchanges->changes.back()->final_entry;
                 log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
-            } catch (std::exception &e) {
-                log_error(_("Couldn't parse: %1%"), remote->filespec);
-                std::cerr << e.what() << std::endl;
             }
 
         } catch (std::exception &e) {

--- a/galaxy/changeset.cc
+++ b/galaxy/changeset.cc
@@ -513,28 +513,4 @@ ChangeSetFile::on_start_element(const Glib::ustring &name,
 }
 #endif // EOF LIBXML
 
-std::string
-fixString(std::string text)
-{
-    std::string newstr;
-    int i = 0;
-    while (i < text.size()) {
-        if (text[i] == '\'') {
-            newstr += "&apos;";
-        } else if (text[i] == '\"') {
-            newstr += "&quot;";
-        } else if (text[i] == ')') {
-            newstr += "&#41;";
-        } else if (text[i] == '(') {
-            newstr += "&#40;";
-        } else if (text[i] == '\\') {
-            // drop this character
-        } else {
-            newstr += text[i];
-        }
-        i++;
-    }
-    return boost::locale::conv::to_utf<char>(newstr, "Latin1");
-}
-
 } // namespace changeset

--- a/galaxy/changeset.hh
+++ b/galaxy/changeset.hh
@@ -72,9 +72,6 @@ namespace changeset {
 extern bool
 IsControl(int i);
 
-extern std::string
-fixString(std::string text);
-
 /// \file changeset.hh
 /// \brief The file is used for processing changeset files
 ///
@@ -98,13 +95,13 @@ class ChangeSet {
     void dump(void);
 
     /// Add a hashtag to internal storage
-    void addHashtags(std::string text) { hashtags.push_back(fixString(text)); };
+    void addHashtags(std::string text) { hashtags.push_back(text); };
 
     /// Add the comment field, which is often used for hashtags
-    void addComment(std::string text) { comment = fixString(text); };
+    void addComment(std::string text) { comment = text; };
 
     /// Add the editor field
-    void addEditor(std::string text) { editor = fixString(text); };
+    void addEditor(std::string text) { editor = text; };
 
     // protected so testcases can access private data
     // protected:

--- a/galaxy/galaxy.cc
+++ b/galaxy/galaxy.cc
@@ -223,7 +223,7 @@ QueryGalaxy::applyChange(const changeset::ChangeSet &change) const
     }
 
     query += ", bbox) VALUES(";
-    query += std::to_string(change.id) + ",\'" + changeset::fixString(change.editor) + "\',\'";
+    query += std::to_string(change.id) + ",\'" + sdb->esc(changeset::fixString(change.editor)) + "\',\'";
 
     query += std::to_string(change.uid) + "\',\'";
     query += to_simple_string(change.created_at) + "\', \'";
@@ -329,7 +329,7 @@ QueryGalaxy::applyChange(const changeset::ChangeSet &change) const
 
     query += ")\')";
     // query += ")) ON CONFLICT DO NOTHING;";
-    query += ")) ON CONFLICT (id) DO UPDATE SET editor=\'" + changeset::fixString(change.editor);
+    query += ")) ON CONFLICT (id) DO UPDATE SET editor=\'" +  sdb->esc(changeset::fixString(change.editor));
     query += "\', created_at=\'" + to_simple_string(change.created_at);
     // if (!change.open) {
     // 	query += "\', closed_at=\'" + to_simple_string(change.closed_at);

--- a/galaxy/galaxy.hh
+++ b/galaxy/galaxy.hh
@@ -168,6 +168,7 @@ class QueryGalaxy : public pq::Pq {
     std::vector<RawUser> users; ///< All the raw user data
 
   private:
+    std::string fixString(std::string text) const;
     mutable std::mutex changes_write_mutex; ///< Mutex for data acccess when writing
                                             ///< to the database
 };


### PR DESCRIPTION
Underpass was crashing from time to time showing an error message related to the PostgreSQL query:

```
terminate called after throwing an instance of 'pqxx::syntax_error'
  what():  ERROR:  unterminated quoted string at or near "'JOSM/1.5 &#40;17491 en&#41"
LINE 1: ..._at, updated_at, hashtags , bbox) VALUES(99502851,'JOSM/1.5 ...
```

This crash stopped to happen after adding an escape function to be run over`change.editor` string. This string was filtered by the `fixString` function but that was not enough, as this variable can have any input.