### PR TITLE
Fix for empty OsmChange file

### DIFF
--- a/data/threads.cc
+++ b/data/threads.cc
@@ -359,8 +359,10 @@ threadOsmChange(std::shared_ptr<replication::RemoteURL> &remote,
             try {
                 osmchanges->readXML(changes_xml);  
                 task.processed = true;
-                task.timestamp = osmchanges->changes.back()->final_entry;
-                log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
+                if (osmchanges->changes.size() > 0) {
+                    task.timestamp = osmchanges->changes.back()->final_entry;
+                    log_debug(_("OsmChange final_entry: %1%"), task.timestamp);
+                }
             } catch (std::exception &e) {
                 log_error(_("Couldn't parse: %1%"), remote->filespec);
                 std::cerr << e.what() << std::endl;


### PR DESCRIPTION
There are special cases where the OsmChange file have no changes, so accessing `final_entry` was causing a crash.
