### PR TITLE
Add Forwarded_allow_ips envvar to fix OAuth2 issue

### DIFF
--- a/infra/galaxy-api.tf
+++ b/infra/galaxy-api.tf
@@ -182,6 +182,10 @@ resource "aws_ecs_task_definition" "galaxy-api" {
       }
 
       environment = [
+        {
+          name  = "FORWARDED_ALLOW_IPS"
+          value = "*"
+        }
 
       ]
     }


### PR DESCRIPTION
Add `FORWARDED_ALLOW_IPS` as an envvar to tell FastAPI to allow any IP to set `X-Forwarded` headers.