### PR TITLE
Various fixes to cloudfront and RDS

### DIFF
--- a/infra/infra.tf
+++ b/infra/infra.tf
@@ -15,6 +15,13 @@ data "aws_acm_certificate" "hotosm-wildcard" {
 
 }
 
+data "aws_cloudfront_cache_policy" "galaxy" {
+  name = "CachingOptimized"
+}
+
+data "aws_cloudfront_origin_request_policy" "galaxy" {
+  name = "UserAgentRefererHeaders"
+}
 
 ## TODO:
 # Add Origin Access Policy
@@ -31,7 +38,6 @@ resource "aws_cloudfront_distribution" "galaxy" {
     origin_id   = "galaxy-website"
   }
 
-
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
@@ -39,6 +45,10 @@ resource "aws_cloudfront_distribution" "galaxy" {
     compress               = true
     target_origin_id       = "galaxy-website"
 
+    cache_policy_id          = data.aws_cloudfront_cache_policy.galaxy.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.galaxy.id
+
+    // LEGACY
     forwarded_values {
       cookies {
         forward = "all"
@@ -355,8 +365,7 @@ resource "aws_db_subnet_group" "galaxy" {
 resource "aws_db_instance" "galaxy" {
   lifecycle {
     ignore_changes = [
-      # Updated manually or by other processes
-      // max_allocated_storage,
+      engine_version
 
       # Manually updated often
       // instance_class,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -207,6 +207,14 @@ resource "aws_security_group" "app" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
+  ingress {
+    description     = "Allow access to Bastion"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.remote-access.id]
+  }
+
   egress {
     from_port        = 0
     to_port          = 0
@@ -244,6 +252,12 @@ resource "aws_security_group" "remote-access" {
 
   tags = {
     Name = "galaxy-remote-user-access"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      ingress
+    ]
   }
 
 }


### PR DESCRIPTION
- Fix Cloudfront Caching policy and origin request policy
- Ignore RDS engine version changes outside of Terraform
- Add Bastion access to APP security group
- Ignore ingress changes to Bastion security group outside of Terraform