### PR TITLE
Query for cleaning DB every 24 hours

### DIFF
--- a/data/clean-osmchanges.sql
+++ b/data/clean-osmchanges.sql
@@ -6,4 +6,4 @@ We run this query every 24 hours for cleaning the database
 when running the replicator process with areaFilter disabled 
 for osmchanges (--osmnoboundary).
 */
-DELETE FROM changesets WHERE bbox is null and closed_at < NOW() - INTERVAL '24 HOURS';
+DELETE FROM changesets WHERE bbox is null and updated_at < NOW() - INTERVAL '24 HOURS' RETURNING id;

--- a/data/clean-osmchanges.sql
+++ b/data/clean-osmchanges.sql
@@ -1,0 +1,9 @@
+/*
+This query deletes entries created from OsmChanges,
+closed 1 day back or before , that has no corresponding Changeset.
+
+We run this query every 24 hours for cleaning the database
+when running the replicator process with areaFilter disabled 
+for osmchanges (--osmnoboundary).
+*/
+DELETE FROM changesets WHERE bbox is null and closed_at < NOW() - INTERVAL '24 HOURS';

--- a/data/clean-osmchanges.sql
+++ b/data/clean-osmchanges.sql
@@ -6,4 +6,4 @@ We run this query every 24 hours for cleaning the database
 when running the replicator process with areaFilter disabled 
 for osmchanges (--osmnoboundary).
 */
-DELETE FROM changesets WHERE bbox is null and updated_at < NOW() - INTERVAL '24 HOURS' RETURNING id;
+DELETE FROM changesets WHERE bbox is null and closed_at < NOW() - INTERVAL '24 HOURS' RETURNING id;


### PR DESCRIPTION
This query deletes entries created from OsmChanges, closed 1 day back or before , that has no corresponding Changeset.

We'll use a cron job like this for running the query:

`0 4 * * * . $HOME/.profile && psql -d $GALAXY_DB -t -f $UNDERPASS_CLEAN_QUERY`