### PR TITLE
Update Galaxy-API configuration

### DIFF
--- a/infra/config.txt.tftpl
+++ b/infra/config.txt.tftpl
@@ -1,14 +1,11 @@
-[DATABASE]
-host=localhost
-user=
-password=
-dbname=
-port=
-
-;
-[HOST]
-host=${api_url}
-port=${api_port}
+; max_area tested upto 16000000 (sq km)
+[API_CONFIG]
+export_path=exports/
+api_host=${api_url}
+api_port=${api_port}
+max_area=${api_export_max_area}
+use_connection_pooling=False
+log_level=${api_log_level}
 
 ; OAuth2 Credentials for OSM.org login
 [OAUTH]
@@ -17,31 +14,28 @@ ${k}=${v}
 %{ endfor ~}
 url=https://www.openstreetmap.org
 scope=read_prefs
-login_redirect_uri=${api_url}/auth/callback
-
-; Database downloads
-[DUMP]
-path=${dump_path}
-redirect_uri=${api_url}/callback
-underpass=underpass.sql
-osmstats=osmstats.sql
+login_redirect_uri=${api_url}/v1/auth/callback/
 
 ; Insights database access credentials
 [INSIGHTS]
-%{ for k, v in insights_creds ~}
+%{ for k, v in insights_db_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
 ; Underpass database access credentials
 [UNDERPASS]
-%{ for k, v in underpass_creds ~}
+%{ for k, v in underpass_db_creds ~}
+${k}=${v}
+%{ endfor ~}
+
+[RAW_DATA]
+%{ for k, v in galaxy_db_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
 ; Tasking Manager database access credentials
-; TODO: Rename section title
 [TM]
-%{ for k, v in tasking_manager_creds ~}
+%{ for k, v in tasking_manager_db_creds ~}
 ${k}=${v}
 %{ endfor ~}
 
@@ -49,9 +43,7 @@ ${k}=${v}
 url=${sentry_dsn}
 rate=1.0
 
-; If API and UI are on different hosts
-[EXPORT_CONFIG]
-path=exports/
-api_host=http://127.0.0.1
-api_port=8000
-max_area=100000
+; ACCESS KEY AND SECRET KEY implicit
+[EXPORT_UPLOAD]
+FILE_UPLOAD_METHOD=s3
+BUCKET_NAME=${export_upload_bucket_name}

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -140,8 +140,14 @@ resource "aws_security_group" "database" {
 
 resource "aws_security_group" "database-administration" {
   name        = "database-administration"
-  description = "Restricted Temporary Access to Galaxy Database"
+  description = "Ephemeral user access to Galaxy Database"
   vpc_id      = aws_vpc.galaxy.id
+
+  lifecycle {
+    ignore_changes = [
+      ingress,
+    ]
+  }
 
   ingress {
     description = "Allow from self"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,6 +19,20 @@ variable "quay_robot_credentials" {
   sensitive = true
 }
 
+variable "galaxy_db_credentials" {
+  type = map(string)
+
+  default = {
+    host     = "localhost"
+    port     = "5432"
+    database = "postgres"
+    user     = "postgres_dba"
+    password = "secret123"
+  }
+
+  sensitive = true
+}
+
 variable "tasking_manager_db_credentials" {
   type = map(string)
 
@@ -178,11 +192,6 @@ variable "tasking-manager_vpc_id" {
   default = "vpc-ea28198f"
 }
 
-variable "dump_path" {
-  type    = string
-  default = "/var/log/galaxy-api"
-}
-
 variable "container_image_uri" {
   type    = string
   default = "quay.io/hotosm/galaxy-api:container"
@@ -201,6 +210,16 @@ variable "api_host" {
 variable "api_port" {
   type    = string
   default = "443"
+}
+
+variable "api_export_max_area" {
+  type    = string
+  default = "3000000"
+}
+
+variable "api_log_level" {
+  type    = string
+  default = "info"
 }
 
 variable "api_url_scheme" {


### PR DESCRIPTION
- Update Galaxy API configuration file to the latest format
- Add Galaxy DB credentials to config file
- Update callback URL format
- Ignore changes to ingress rules in DB administration security group
- Remove extraneous resource scope from IAM role
- Converted hardcoded deployment-environment to variable parameters
- Upgrade health check path to versioned API format
- Add new S3 Bucket and associated access policies
- Add lifecycle policy for S3 bucket - expires in 90 days
- Modify variables to add export area and log level

TODO:
- Make Insights, Underpass and TM databases point to read-only proxy
  endpoints
- Parameterize healthcheck endpoint API versions