### PR TITLE
Stats for relations. Updated stats config. Restored missing merged code.

### DIFF
--- a/data/statsconfig.hh
+++ b/data/statsconfig.hh
@@ -44,12 +44,14 @@ namespace statsconfig {
             std::string name;
             std::map<std::string, std::vector<std::string>> way;
             std::map<std::string, std::vector<std::string>> node;
+            std::map<std::string, std::vector<std::string>> relation;
             StatsConfig(std::string name);
             StatsConfig
             (
                 std::string name,
                 std::map<std::string, std::vector<std::string>> way,
-                std::map<std::string, std::vector<std::string>> node
+                std::map<std::string, std::vector<std::string>> node,
+                std::map<std::string, std::vector<std::string>> relation
             );
     };
 

--- a/galaxy/osmchange.hh
+++ b/galaxy/osmchange.hh
@@ -233,8 +233,13 @@ class OsmChangeFile
 #endif
 {
   public:
+
     OsmChangeFile(void){};
-    OsmChangeFile(const std::string &osc) { readChanges(osc); };
+    OsmChangeFile(const std::string &osc) {
+        readChanges(osc);
+    };
+
+    std::string statsConfigFilename = "/validate/statistics.yaml";
 
     /// Read a changeset file from disk or memory into internal storage
     bool readChanges(const std::string &osc);
@@ -247,8 +252,11 @@ class OsmChangeFile
     void on_start_element(const Glib::ustring &name,
                           const AttributeList &properties) override;
 #endif
+
     /// Read an istream of the data and parse the XML
     bool readXML(std::istream &xml);
+
+    void setStatsConfigFilename(std::string filename);
 
     std::map<long, std::shared_ptr<ChangeStats>> userstats; ///< User statistics for this file
 
@@ -274,6 +282,7 @@ class OsmChangeFile
 //    std::map<long, bool> priority;
     /// dump internal data, for debugging only
     void dump(void);
+
 };
 
 } // namespace osmchange

--- a/testsuite/libunderpass.all/stats-test.cc
+++ b/testsuite/libunderpass.all/stats-test.cc
@@ -27,132 +27,123 @@
 #include "replicatorconfig.hh"
 #include "galaxy/planetreplicator.hh"
 #include "data/yaml.hh"
-
+#include "boost/date_time/posix_time/posix_time.hpp"
+#include <boost/date_time.hpp>
 namespace opts = boost::program_options;
 
+using namespace boost::posix_time;
 using namespace replicatorconfig;
 using namespace planetreplicator;
 using namespace logger;
 
-class TestOsmChanges : public osmchange::OsmChangeFile {
-};
-
-class TestCO : public osmchange::OsmChangeFile {
-};
+/// \file stats-test.cc
+/// \brief Testing statistics collection
+///
+/// Using this test you can collect statistics from osmchange
+/// files and assert the results against a YAML file
+/// or save them to a JSON file for other tasks
+///
+/// For documentation see doc/stats-test.md
 
 class TestPlanet : public replication::Planet {
 };
 
-std::string
-statsToJSON(std::shared_ptr<std::map<long, std::shared_ptr<osmchange::ChangeStats>>> stats, std::string filespec) {
-    std::string jsonstr = "";
-    for (auto it = std::begin(*stats); it != std::end(*stats); ++it) {
-        auto changestats = it->second;
-        jsonstr += "{\"changeset_id\":" + std::to_string(changestats->change_id) + ", ";
-        jsonstr += "\"filespec\": \"" + filespec + "\" ";
-
-        if (changestats->added.size() > 0) {
-            jsonstr += ", \"added\":[";
-            for (const auto &added: std::as_const(changestats->added)) {
-                if (added.second > 0) {
-                    jsonstr += "{\"" + added.first + "\":" + std::to_string(added.second) + "},";
-                }
-            }
-            jsonstr.erase(jsonstr.size() - 1);
-            jsonstr += "]";
-        } else {
-            jsonstr += ", \"added\": []";
-        }
-
-        if (changestats->modified.size() > 0) {
-            jsonstr += ", \"modified\":[";
-            for (const auto &modified: std::as_const(changestats->modified)) {
-                if (modified.second > 0) {
-                    jsonstr += "{\"" + modified.first + "\":" + std::to_string(modified.second) + "},";
-                }
-            }
-            jsonstr.erase(jsonstr.size() - 1);
-            jsonstr += "]},\n";
-        } else {
-            jsonstr += ", \"modified\": []},\n";
-        }
-
-    }
-    return jsonstr;
-}
-
-void
-collectStats(opts::variables_map vm) {
-
-    ReplicatorConfig config;    
-    if (vm.count("timestamp")) {
-        auto timestamp = vm["timestamp"].as<std::string>();
-        config.start_time = from_iso_extended_string(timestamp);
-    } else {
-        config.start_time = from_iso_extended_string("2022-01-01T00:00:00");
-    }
-    config.planet_server = config.planet_servers[0].domain + "/replication";
-    multipolygon_t poly;
-    boost::geometry::read_wkt("MULTIPOLYGON(((-180 90,180 90, 180 -90, -180 -90,-180 90)))", poly);
- 
-    int increment;
-    if (vm.count("increment")) {
-        const auto str_increment = vm["increment"].as<std::string>();
-        increment = std::stoi(str_increment) + 1;
-    } else { 
-        increment = 2;
-    }
-    planetreplicator::PlanetReplicator replicator;
-    auto osmchange = replicator.findRemotePath(config, config.start_time);
-    
-    std::string jsonstr = "[";
-
-    while (--increment) {
-        TestCO change;
-        if (boost::filesystem::exists(osmchange->filespec)) {
-            change.readChanges(osmchange->filespec);
-        } else { 
-            TestPlanet planet;
-            auto data = planet.downloadFile(osmchange->getURL());
-            auto xml = planet.processData(osmchange->filespec, *data);
-            std::istream& input(xml);
-            change.readXML(input);
-        }
-
-        change.areaFilter(poly);
-        auto stats = change.collectStats(poly);
-        jsonstr += statsToJSON(stats, osmchange->filespec);
-
-        osmchange->Increment();
-    }
-
-    jsonstr.erase(jsonstr.size() - 2);
-    jsonstr += "\n]";
-    std::cout << jsonstr << std::endl;
-
-}
-
-
 class TestStats {
 
-    private:
-        bool verbose;
     public:
-        TestStats() {
-            this->verbose = false;
-        };
-        TestStats(bool verbosity) {
-            this->verbose = verbosity;
-        };
-        std::shared_ptr<std::map<long, std::shared_ptr<osmchange::ChangeStats>>>
+        TestStats() {};
 
+        std::string statsConfigFile = "/validate/statistics.yaml";
+        ptime startTime = boost::posix_time::second_clock::universal_time();
+        int increment = 2;
+        bool verbose = false;
+        multipolygon_t boundary;
+
+        std::string
+        statsToJSON(std::shared_ptr<std::map<long, std::shared_ptr<osmchange::ChangeStats>>> stats, std::string filespec) {
+            std::string jsonstr = "";
+            for (auto it = std::begin(*stats); it != std::end(*stats); ++it) {
+                auto changestats = it->second;
+                jsonstr += "{\"changeset_id\":" + std::to_string(changestats->change_id) + ", ";
+                jsonstr += "\"filespec\": \"" + filespec + "\" ";
+
+                if (changestats->added.size() > 0) {
+                    jsonstr += ", \"added\":[";
+                    for (const auto &added: std::as_const(changestats->added)) {
+                        if (added.second > 0) {
+                            jsonstr += "{\"" + added.first + "\":" + std::to_string(added.second) + "},";
+                        }
+                    }
+                    jsonstr.erase(jsonstr.size() - 1);
+                    jsonstr += "]";
+                } else {
+                    jsonstr += ", \"added\": []";
+                }
+
+                if (changestats->modified.size() > 0) {
+                    jsonstr += ", \"modified\":[";
+                    for (const auto &modified: std::as_const(changestats->modified)) {
+                        if (modified.second > 0) {
+                            jsonstr += "{\"" + modified.first + "\":" + std::to_string(modified.second) + "},";
+                        }
+                    }
+                    jsonstr.erase(jsonstr.size() - 1);
+                    jsonstr += "]},\n";
+                } else {
+                    jsonstr += ", \"modified\": []},\n";
+                }
+
+            }
+            return jsonstr;
+        }
+
+        void
+        collectStats(opts::variables_map vm) {
+
+            ReplicatorConfig config;
+            config.start_time = startTime;
+            config.planet_server = config.planet_servers[0].domain + "/replication";
+            planetreplicator::PlanetReplicator replicator;
+            auto osmchange = replicator.findRemotePath(config, config.start_time);
+
+            std::string jsonstr = "[";
+
+            while (--increment) {
+                osmchange::OsmChangeFile change;
+                change.setStatsConfigFilename(statsConfigFile);
+                if (boost::filesystem::exists(osmchange->filespec)) {
+                    change.readChanges(osmchange->filespec);
+                } else {
+                    TestPlanet planet;
+                    auto data = planet.downloadFile(osmchange->getURL());
+                    auto xml = planet.processData(osmchange->filespec, *data);
+                    std::istream& input(xml);
+                    change.readXML(input);
+                }
+
+                change.areaFilter(boundary);
+                auto stats = change.collectStats(boundary);
+                jsonstr += statsToJSON(stats, osmchange->filespec);
+
+                osmchange->Increment();
+            }
+
+            jsonstr.erase(jsonstr.size() - 2);
+            jsonstr += "\n]";
+            std::cout << jsonstr << std::endl;
+
+        }
+
+        std::shared_ptr<std::map<long, std::shared_ptr<osmchange::ChangeStats>>>
         getStatsFromFile(std::string filename) {
-            TestOsmChanges osmchanges;
+            osmchange::OsmChangeFile osmchanges;
+            osmchanges.setStatsConfigFilename(statsConfigFile);
             osmchanges.readChanges(filename);
-            multipolygon_t poly;
-            boost::geometry::read_wkt("MULTIPOLYGON(((-180 90,180 90, 180 -90, -180 -90,-180 90)))", poly);
-            osmchanges.areaFilter(poly);
-            auto stats = osmchanges.collectStats(poly);
+            osmchanges.areaFilter(boundary);
+            if (this->verbose) {
+                osmchanges.dump();
+            }
+            auto stats = osmchanges.collectStats(boundary);
             return stats;
         }
 
@@ -174,8 +165,6 @@ class TestStats {
         void
         testStat(std::shared_ptr<osmchange::ChangeStats> changestats, std::map<std::string, long> validation, std::string tag) {
 
-            TestState runtest;
-
             logger::LogFile &dbglogfile = logger::LogFile::getDefaultInstance();
             dbglogfile.setWriteDisk(true);
             dbglogfile.setLogFilename("stats-test.log");
@@ -196,8 +185,10 @@ class TestStats {
                         }
                     }
                     if (validation.count("added_" + tag) && changestats->added.at(tag) == validation.at("added_" + tag)) {
+                        TestState runtest;
                         runtest.pass("Calculating added " + tag);
                     } else{
+                        TestState runtest;
                         runtest.fail("Calculating added " + tag);
                     }
                 } else if (this->verbose) {
@@ -217,8 +208,10 @@ class TestStats {
                         std::cout << "[Underpass] modified_" + tag + " : " << changestats->modified.at(tag) << std::endl;
                     }
                     if (validation.count("modified_" + tag) && changestats->modified.at(tag) == validation.at("modified_" + tag)) {
+                        TestState runtest;
                         runtest.pass("Calculating modified " + tag);
                     } else {
+                        TestState runtest;
                         runtest.fail("Calculating modified " + tag);
                     }
                 } else if (this->verbose) {
@@ -245,8 +238,13 @@ class TestStats {
                     if (this->verbose) {
                         std::cout << "change_id: " << changestats->change_id << std::endl;
                     }
+                    // TODO: get values to test from YAML validation file
                     testStat(changestats, validation, "highway");
                     testStat(changestats, validation, "building");
+                    testStat(changestats, validation, "humanitarian_building");
+                    testStat(changestats, validation, "police");
+                    testStat(changestats, validation, "fire_station");
+                    testStat(changestats, validation, "hospital");
                     testStat(changestats, validation, "waterway");
                 }
             }
@@ -264,18 +262,42 @@ main(int argc, char *argv[]) {
         ("file,f", opts::value<std::vector<std::string>>(), "OsmChange file, YAML file with expected values")
         ("timestamp,t", opts::value<std::string>(), "Starting timestamp (default: 2022-01-01T00:00:00)")
         ("increment,i", opts::value<std::string>(), "Number of increments to do (default: 1)")
+        ("statsconfigfile", opts::value<std::string>(), "Statistics configuration file")
+        ("boundary", opts::value<std::string>(), "Statistics configuration file")
         ("verbose,v", "Enable verbosity");
 
     opts::store(opts::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     opts::notify(vm);
 
+    TestStats testStats;
+
+    geoutil::GeoUtil geou;
+    if (vm.count("boundary")) {
+        if (!geou.readFile(vm["boundary"].as<std::string>())) {
+            return 0;
+        }
+        testStats.boundary = geou.boundary;
+    }
+    if (vm.count("timestamp")) {
+        testStats.startTime = from_iso_extended_string(vm["timestamp"].as<std::string>());
+    }
+    if (vm.count("statsconfigfile")) {
+        testStats.statsConfigFile = vm["statsconfigfile"].as<std::string>();
+    }
+    if (vm.count("verbose")) {
+        testStats.verbose = true;
+    }
+    if (vm.count("increment")) {
+        const auto str_increment = vm["increment"].as<std::string>();
+        testStats.increment = std::stoi(str_increment) + 1;
+    }
+
     if (vm.count("mode")) {
         // Collect stats
         if (vm["mode"].as<std::string>() == "collect-stats") {
-            collectStats(vm);
+            testStats.collectStats(vm);
         }
     } else if (vm.count("file")) {
-        TestStats testStats(vm.count("verbose"));
         auto files = vm["file"].as<std::vector<std::string>>();
 
         if (files.size() == 2) {
@@ -286,14 +308,13 @@ main(int argc, char *argv[]) {
             std::string statsFile(DATADIR);
             statsFile += "/testsuite/testdata/" + files.at(0);
             auto stats = testStats.getStatsFromFile(statsFile);
-            std::string jsonstr = statsToJSON(stats, statsFile);
+            std::string jsonstr = testStats.statsToJSON(stats, statsFile);
             jsonstr.erase(jsonstr.size() - 2);
             std::cout << jsonstr << std::endl;
         }
     } else {
         // Default OsmChange + validation file
-        TestStats testStats(vm.count("verbose"));
-        std::vector<std::string> files = {"test_stats.osc", "test_stats.yaml"};
+        std::vector<std::string> files = {"stats/test_stats.osc", "stats/test_stats.yaml"};
         testStats.validateStatsFromFile(files);
     }
 

--- a/testsuite/libunderpass.all/statsconfig-test.cc
+++ b/testsuite/libunderpass.all/statsconfig-test.cc
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 
     statsconfig::StatsConfigFile statsconfigfile;
     std::string filename = DATADIR;
-    filename += "/testsuite/testdata/statsconfig.yaml";
+    filename += "/testsuite/testdata/stats/statsconfig.yaml";
     std::shared_ptr<std::vector<statsconfig::StatsConfig>> statsconfig = statsconfigfile.read_yaml(filename);
 
     if (

--- a/testsuite/testdata/stats/statsconfig.yaml
+++ b/testsuite/testdata/stats/statsconfig.yaml
@@ -1,0 +1,33 @@
+buildings:
+  way:
+    - underpass_tag:
+      - underpass_test
+    - building:
+      - yes
+      - school
+    - amenity:
+      - hospital
+      - emergency
+  node:
+    - amenity:
+      - school
+    - underpass_tag:
+      - underpass_test
+
+amenities:
+  node:
+    - amenity:
+      - emergency
+
+highways:
+  way:
+    - highway:
+      - yes
+
+underpass_category:
+  way:
+    - underpass_tag2:
+      - underpass_test
+  node:
+    - underpass_tag2:
+      - underpass_test

--- a/testsuite/testdata/stats/statsconfig2.yaml
+++ b/testsuite/testdata/stats/statsconfig2.yaml
@@ -1,0 +1,25 @@
+hospital:
+  node:
+    - building:
+      - hospital
+    - emergency:
+      - hospital
+
+fire_station:
+  node:
+    - building:
+      - fire_station
+    - emergency:
+      - fire_station
+
+police:
+  node:
+    - emergency:
+      - police_station
+
+building:
+  node:
+    - building:
+      - *
+
+

--- a/testsuite/testdata/stats/statsconfig3.yaml
+++ b/testsuite/testdata/stats/statsconfig3.yaml
@@ -1,0 +1,17 @@
+humanitarian_building:
+  node:
+    - emergency:
+      - hospital
+      - fire_station
+    - building:
+      - hospital
+      - fire_station
+
+building:
+  node:
+    - emergency:
+      - police_station
+    - building:
+      - *
+
+

--- a/testsuite/testdata/stats/test_stats.osc
+++ b/testsuite/testdata/stats/test_stats.osc
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="manually_generated/1.8.0">
+    <create>
+        <way id="821663801" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z" uid="1" user="some_user">
+            <nd ref="6353646374"/>
+            <nd ref="7672025813"/>
+            <nd ref="7672025812"/>
+            <nd ref="7672025811"/>
+            <nd ref="7672025810"/>
+            <nd ref="7672025809"/>
+            <nd ref="7672025808"/>
+            <nd ref="6353634308"/>
+            <tag k="highway" v="residential"/>
+        </way>
+    </create>
+    <create>
+        <way id="1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+            <nd ref="1"/>
+            <nd ref="2"/>
+            <tag k="highway" v="residential"/>
+        </way>
+    </create>
+    <create>
+        <way id="2" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+            <nd ref="3"/>
+            <nd ref="4"/>
+            <tag k="highway" v="path"/>
+        </way>
+    </create>
+    <modify>
+        <way id="815923836" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z" uid="1" user="some_user">
+            <nd ref="7620338992"/>
+            <nd ref="7620338993"/>
+            <nd ref="7620338994"/>
+            <nd ref="7620338995"/>
+            <nd ref="7620338996"/>
+            <nd ref="7620338997"/>
+            <nd ref="7620338998"/>
+            <nd ref="7620338999"/>
+            <nd ref="7620339000"/>
+            <nd ref="7620339001"/>
+            <nd ref="7620339002"/>
+            <nd ref="7620338991"/>
+            <nd ref="7620339003"/>
+            <nd ref="7620339004"/>
+            <nd ref="7620339005"/>
+            <nd ref="7620339006"/>
+            <nd ref="7620339007"/>
+            <nd ref="7620339008"/>
+            <nd ref="7620339009"/>
+            <tag k="highway" v="residential"/>
+        </way>
+    </modify>
+    <modify>
+        <way id="815951903" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"  uid="1" user="some_user">
+            <nd ref="2281630522"/>
+            <nd ref="7620520783"/>
+            <nd ref="7620520784"/>
+            <nd ref="7620575085"/>
+            <nd ref="7620575086"/>
+            <nd ref="7620575087"/>
+            <nd ref="7620575088"/>
+            <nd ref="7620575089"/>
+            <nd ref="7620339009"/>
+            <tag k="highway" v="residential"/>
+        </way>
+    </modify>
+    <create>
+        <way id="119581708" version="1" changeset="1"
+	 timestamp="2012-07-10T00:00:00Z" user="some_user" uid="1">
+            <nd ref="1343167240"/>
+            <nd ref="1343167236"/>
+            <nd ref="1343167238"/>
+            <nd ref="1343167235"/>
+            <nd ref="1343167237"/>
+            <nd ref="1343167239"/>
+            <nd ref="1343167240"/>
+            <tag k="building" v="yes"/>
+        </way>
+        <way id="474556695" version="1" timestamp="2021-02-11T01:56:35Z" uid="1" user="some_user" changeset="1">
+            <nd ref="4684837925"/>
+            <nd ref="4684837923"/>
+            <nd ref="4425965490"/>
+            <nd ref="4684837924"/>
+            <tag k="waterway" v="river"/>
+        </way>
+        <way id="474556695" version="1" timestamp="2021-02-11T01:56:35Z" uid="1" user="some_user" changeset="1">
+            <nd ref="4684837925"/>
+            <nd ref="4684837923"/>
+            <nd ref="4425965490"/>
+            <nd ref="4684837924"/>
+            <tag k="underpass_way" v="test"/>
+        </way>
+    </create>
+    <create>
+        <node id="44" lat="25.8437789" lon="82.6640564" user="some_user" uid="1" version="1" changeset="1" timestamp="2021-02-11T01:56:35Z">
+            <tag k="name" v="Some other interesting point (44)"/>
+            <tag k="addr:housename" v="My house name at N°5" />
+            <tag k="underpass_node" v="test" />
+        </node>
+    </create>
+    <modify>
+        <way id="119581708" version="1" changeset="1"
+	 timestamp="2012-07-10T00:00:00Z" user="some_user" uid="1">
+            <nd ref="1343167240"/>
+            <nd ref="1343167236"/>
+            <nd ref="1343167238"/>
+            <nd ref="1343167235"/>
+            <nd ref="1343167237"/>
+            <nd ref="1343167239"/>
+            <tag k="waterway" v="stream"/>
+        </way>
+        <way id="821663069" version="1" timestamp="2020-06-30T23:01:19Z" changeset="1" uid="1" user="some_user">
+            <nd ref="7672024395"/>
+            <nd ref="7672024396"/>
+            <nd ref="7672024397"/>
+            <nd ref="7672024398"/>
+            <nd ref="7672024395"/>
+            <tag k="building" v="yes"/>
+        </way>
+    </modify>
+    <create>
+        <relation id="821663901" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z" uid="1" user="some_user">
+            <nd ref="6353646374"/>
+            <nd ref="7672025813"/>
+            <nd ref="7672025812"/>
+            <nd ref="7672025811"/>
+            <nd ref="7672025810"/>
+            <nd ref="7672025809"/>
+            <nd ref="7672025808"/>
+            <nd ref="6353634308"/>
+            <tag k="building" v="market"/>
+        </way>
+    </create>
+</osmChange>

--- a/testsuite/testdata/stats/test_stats.yaml
+++ b/testsuite/testdata/stats/test_stats.yaml
@@ -1,0 +1,14 @@
+- change_id:
+  - 1
+- modified_highway:
+  - 2
+- added_highway:
+  - 3
+- modified_building:
+  - 1
+- added_building:
+  - 2
+- modified_waterway:
+  - 1
+- added_waterway:
+  - 1

--- a/testsuite/testdata/stats/test_statsconfig.osc
+++ b/testsuite/testdata/stats/test_statsconfig.osc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="1" generator="manually_generated">
+    <create>
+        <node id="0" changeset="1">
+            <tag k="building" v="hospital"/>
+        </node>
+    </create>
+    <create>
+        <node id="0" changeset="1">
+            <tag k="building" v="fire_station"/>
+        </node>
+    </create>
+    <create>
+        <node id="0" changeset="1">
+            <tag k="building" v="yes"/>
+        </node>
+    </create>
+    <create>
+        <node id="0" changeset="1">
+            <tag k="emergency" v="hospital"/>
+        </node>
+    </create>
+    <create>
+        <node id="0" changeset="1">
+            <tag k="emergency" v="fire_station"/>
+        </node>
+    </create>
+    <create>
+        <node id="0" changeset="1">
+            <tag k="emergency" v="police_station"/>
+        </node>
+    </create>
+    <!-- This change will be ignored as it have value=null-->
+    <create>
+        <node id="0" changeset="1">
+            <tag k="building" v=""/>
+        </node>
+    </create>
+</osmChange>

--- a/testsuite/testdata/stats/test_statsconfig2.yaml
+++ b/testsuite/testdata/stats/test_statsconfig2.yaml
@@ -1,0 +1,11 @@
+- change_id:
+  - 1
+- added_building:
+  - 1
+- added_fire_station:
+  - 2
+- added_hospital:
+  - 2
+- added_police:
+  - 1
+

--- a/testsuite/testdata/stats/test_statsconfig3.yaml
+++ b/testsuite/testdata/stats/test_statsconfig3.yaml
@@ -1,0 +1,7 @@
+- change_id:
+  - 1
+- added_building:
+  - 2
+- added_humanitarian_building:
+  - 4
+

--- a/validate/statistics.yaml
+++ b/validate/statistics.yaml
@@ -5,6 +5,9 @@ building:
   node:
     - building:
       - *
+  relation:
+    - building:
+      - *
 
 shop:
   node:
@@ -13,15 +16,27 @@ shop:
   way:
     - shop:
       - *
+  relation:
+    - shop:
+      - *
 
 waterway:
   way:
-    - river
-    - canal
-    - stream
-    - brook
-    - drain
-    - ditch
+    - waterway:
+      - river
+      - canal
+      - stream
+      - brook
+      - drain
+      - ditch
+  relation:
+    - waterway:
+      - river
+      - canal
+      - stream
+      - brook
+      - drain
+      - ditch
 
 amenity:
   node:
@@ -30,9 +45,15 @@ amenity:
   way:
     - amenity:
       - *
+  relation:
+    - amenity:
+      - *
 
 highway:
   way:
+    - highway:
+      - *
+  relation:
     - highway:
       - *
 


### PR DESCRIPTION
This long merge has one new feature, one update and code that was merged but was missed after a rebase (sorry for that).

### New feature: stats for relations

Now stats are collected from nodes, ways and relations too. 

### Update: stats configuration

Relation was added for all stats categories and waterway was fixed.

### Missing merged code

A PR was approved but code was lost after a rebase:

#273 - "Set stats config file on OsmChangeFile, Improvements for stats test, ignore stats for value=null"
