### PR TITLE
Small performance improvements

### DIFF
--- a/data/statsconfig.cc
+++ b/data/statsconfig.cc
@@ -88,33 +88,37 @@ namespace statsconfig {
         return statsconfig::statsconfigs.at(filename);
     }
 
-    std::string StatsConfigSearch::category(std::string tag, std::string value, std::map<std::string, std::vector<std::string>> tags) {
+    bool StatsConfigSearch::category(std::string tag, std::string value, std::map<std::string, std::vector<std::string>> tags) {
         for (auto tag_it = std::begin(tags); tag_it != std::end(tags); ++tag_it) {
             if (tag == tag_it->first) {
+                if (tag_it->second.front() == "*") {
+                    return true;
+                }
                 for (auto value_it = std::begin(tag_it->second); value_it != std::end(tag_it->second); ++value_it) {
-                    if (!value.empty() && (*value_it == "*" || value == *value_it)) {
-                        return *value_it;
+                    if (value == *value_it) {
+                        return true;
                     }
                 }
             }
         }
-        return "";
+        return false;
     };
+
     std::string StatsConfigSearch::tag_value(std::string tag, std::string value, osmchange::osmtype_t type, std::shared_ptr<std::vector<StatsConfig>> statsconfig) {
-        std::string category = "";
+        bool category = false;
         for (int i = 0; i < statsconfig->size(); ++i) {
-            if (type == osmchange::way) {
-                category = StatsConfigSearch::category(tag, value, statsconfig->at(i).way);
-            } else if (type == osmchange::node) {
+            if (type == osmchange::node) {
                 category = StatsConfigSearch::category(tag, value, statsconfig->at(i).node);
+            } else if (type == osmchange::way) {
+                category = StatsConfigSearch::category(tag, value, statsconfig->at(i).way);
             } else if (type == osmchange::relation) {
                 category = StatsConfigSearch::category(tag, value, statsconfig->at(i).relation);
             }
-            if (!category.empty()) {
+            if (category) {
                 return statsconfig->at(i).name;
             }
         }
-        return category;
+        return "";
     }
 
 

--- a/data/statsconfig.hh
+++ b/data/statsconfig.hh
@@ -63,7 +63,7 @@ namespace statsconfig {
     class StatsConfigSearch {
         public:
             static std::string tag_value(std::string tag, std::string value, osmchange::osmtype_t type, std::shared_ptr<std::vector<StatsConfig>> statsconfig);
-            static std::string category(std::string tag, std::string value, std::map<std::string, std::vector<std::string>> tags);
+            static bool category(std::string tag, std::string value, std::map<std::string, std::vector<std::string>> tags);
     };
 
 } // EOF statsconfig namespace

--- a/galaxy/osmchange.cc
+++ b/galaxy/osmchange.cc
@@ -679,29 +679,24 @@ OsmChangeFile::scanTags(std::map<std::string, std::string> tags, osmchange::osmt
     statsconfig::StatsConfigFile statsconfigfile;
     std::string path = SRCDIR;
     path += statsConfigFilename;
-
     std::shared_ptr<std::vector<statsconfig::StatsConfig>> statsconfig = statsconfigfile.read_yaml(path);
     auto hits = std::make_shared<std::vector<std::string>>();
-
-    // Some older nodes in a way wound up with this one tag, which nobody noticed,
-    // so ignore it.
-    if (tags.size() == 1 && tags.find("created_at") != tags.end()) {
-        return hits;
-    }
 
     std::map<std::string, bool> cache;
     statsconfig::StatsConfigSearch search;
     for (auto it = std::begin(tags); it != std::end(tags); ++it) {
-        std::string hit = "";
-        if (type == node) {
-            hit = search.tag_value(it->first, it->second, node, statsconfig);
-        } else if (type == way) {
-            hit = search.tag_value(it->first, it->second, way, statsconfig);
-        } else if (type == relation) {
-            hit = search.tag_value(it->first, it->second, relation, statsconfig);
-        }
-        if (!hit.empty()) {
-            hits->push_back(hit);
+        if (!it->second.empty()) {
+            std::string hit = "";
+            if (type == node) {
+                hit = search.tag_value(it->first, it->second, node, statsconfig);
+            } else if (type == way) {
+                hit = search.tag_value(it->first, it->second, way, statsconfig);
+            } else if (type == relation) {
+                hit = search.tag_value(it->first, it->second, relation, statsconfig);
+            }
+            if (!hit.empty()) {
+                hits->push_back(hit);
+            }
         }
     }
 


### PR DESCRIPTION
- Check for empty tag value before looking for a match on statsconfig, as empty values are ignored. 
- Look for "value=*" before iteration
- Return _bool_ instead of _string_
- Remove "created_at" tag checking as it's being done in the other process

