### PR TITLE
Removals in 1 single query. + Fix: set last task processed as true before loop

### DIFF
--- a/galaxy/galaxy.cc
+++ b/galaxy/galaxy.cc
@@ -334,13 +334,18 @@ QueryGalaxy::applyChange(const changeset::ChangeSet &change) const
 }
 
 bool
-QueryGalaxy::updateValidation(long id)
+QueryGalaxy::updateValidation(std::shared_ptr<std::vector<long>> removals)
 {
 #ifdef TIMING_DEBUG_X
     boost::timer::auto_cpu_timer timer("updateValidation: took %w seconds\n");
 #endif
-    std::string query = "DELETE FROM validation WHERE osm_id=";
-    query += std::to_string(id);
+
+    std::string query = "DELETE FROM validation WHERE osm_id IN(";
+    for (const auto &osm_id : *removals) {
+        query += std::to_string(osm_id) + ",";
+    };
+    query.erase(query.size() - 1);
+    query += ");";
     std::scoped_lock write_lock{pqxx_mutex};
     pqxx::work worker(*sdb);
     pqxx::result result = worker.exec(query);

--- a/galaxy/galaxy.hh
+++ b/galaxy/galaxy.hh
@@ -131,7 +131,7 @@ class QueryGalaxy : public pq::Pq {
     /// Applu data validation to the database
     bool applyChange(const ValidateStatus &validation) const;
     /// Update the validation table, delete any feature that has been fixed.
-    bool updateValidation(long id);
+    bool updateValidation(std::shared_ptr<std::vector<long>> removals);
 
     /// Get the timestamp of the last update in the database
     ptime getLastUpdate(void);


### PR DESCRIPTION
### Removals in 1 single query

Now all removals for updating the validation table are executed in 1 single query, instead of looping the vector and doing multiple calls to the DB.

### Fix: set last task processed as true before loop

This is a small fix that was preventing the increment of replication paths on the first run of threads, delaying the start of the process.
