### PR TITLE
Fix and test for hashtags

### DIFF
--- a/galaxy/changeset.hh
+++ b/galaxy/changeset.hh
@@ -96,7 +96,7 @@ class ChangeSet {
 
     /// Add a hashtag to internal storage
     void addHashtags(std::string text) {
-        hashtags.push_back(text);
+        hashtags.insert(text);
     };
 
     /// Add the comment field, which is often used for hashtags
@@ -127,7 +127,7 @@ class ChangeSet {
                           ///< older changesets)
     int comments_count = 0; ///< The number of comments in this changeset, which
                             ///< appears to be unused
-    std::vector<std::string> hashtags; ///< Internal aray of hashtags in this changeset
+    std::set<std::string> hashtags; ///< Internal dictionary of hashtags in this changeset
     std::string comment; ///< The comment for this changeset
     std::string editor;  ///< The OSM editor the end user used
     std::string source;  ///< The imagery source

--- a/testsuite/libunderpass.all/Makefile.am
+++ b/testsuite/libunderpass.all/Makefile.am
@@ -32,6 +32,7 @@ check_PROGRAMS = \
 	planetreplicator-test \
 	geo-test \
 	areafilter-test \
+	hashtags-test \
 	test-playground
 
 TOPSRC := $(shell cd $(top_srcdir) && pwd)
@@ -138,6 +139,11 @@ areafilter_test_SOURCES = areafilter-test.cc
 areafilter_test_LDFLAGS = -L../..
 areafilter_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
 
+# Hashtags test
+hashtags_test_SOURCES = hashtags-test.cc
+hashtags_test_LDFLAGS = -L../..
+hashtags_test_LDADD = -lpqxx -lunderpass $(BOOST_LIBS)
+
 # Test playground
 test_playground_SOURCES = test-playground.cc
 test_playground_LDFLAGS = -L../..
@@ -156,6 +162,7 @@ CLEANFILES = \
     statsconfig-test.log \
 	planetreplicator-test.log \
 	areafilter-test.log \
+	hashtags-test.log \
 	replication-test.log
 
 RUNTESTFLAGS = -xml

--- a/testsuite/libunderpass.all/hashtags-test.cc
+++ b/testsuite/libunderpass.all/hashtags-test.cc
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2020, 2021, 2022 Humanitarian OpenStreetMap Team
+//
+// This file is part of Underpass.
+//
+//     Underpass is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Underpass is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Underpass.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <iostream>
+#include <dejagnu.h>
+#include "galaxy/changeset.hh"
+#include <boost/algorithm/string.hpp>
+#include <boost/geometry.hpp>
+#include "data/geoutil.hh"
+
+TestState runtest;
+
+using namespace logger;
+
+class TestChangeset : public changeset::ChangeSetFile {};
+
+int
+main(int argc, char *argv[])
+{
+
+    // Changeset with 5 hashtags
+    std::string changesetFile(DATADIR);
+    changesetFile += "/testsuite/testdata/hashtags-test.osc";
+    TestChangeset changeset;
+    changeset::ChangeSet *change;
+    changeset.readChanges(changesetFile);
+    multipolygon_t polyEmpty;
+    changeset.areaFilter(polyEmpty);
+    change = changeset.changes.front().get();
+
+    // for (auto it = std::begin(change->hashtags); it != std::end(change->hashtags); ++it) {
+    //     std::cout << *it << std::endl;
+    // }
+
+    if (change->hashtags.size() == 5) {
+        runtest.pass("ChangeSet hashtags");
+    } else {
+        runtest.fail("ChangeSet hashtags");
+    }
+
+}
+
+// local Variables:
+// mode: C++
+// indent-tabs-mode: nil
+// End:

--- a/testsuite/libunderpass.all/hashtags-test.cc
+++ b/testsuite/libunderpass.all/hashtags-test.cc
@@ -48,7 +48,7 @@ main(int argc, char *argv[])
     //     std::cout << *it << std::endl;
     // }
 
-    if (change->hashtags.size() == 5) {
+    if (change->hashtags.size() == 7) {
         runtest.pass("ChangeSet hashtags");
     } else {
         runtest.fail("ChangeSet hashtags");

--- a/testsuite/testdata/hashtags-test.osc
+++ b/testsuite/testdata/hashtags-test.osc
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="CGImap 0.8.8 (1042616 spike-06.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <changeset id="61497177" created_at="2018-08-09T11:11:18Z" closed_at="2018-08-09T11:11:18Z" open="false" user="salesforcemapping11" uid="8650852" min_lat="-5.6897951" min_lon="36.8454665" max_lat="-5.6897631" max_lon="36.8454960" comments_count="0" changes_count="5">
+  <tag k="changesets_count" v="12"/>
+  <tag k="comment" v="#hotosm-project-4892;#missingmaps;#sh;#sho;#short;#salesforce;#salesforceleads;#salesforcelsUK"/>
+  <tag k="imagery_used" v="Custom (https://{switch:a,b,c,d}.tiles.mapbox.com/v4/digitalglobe.0a8e44ba/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6ImNqZGFrZ3pjczNpaHYycXFyMGo0djY3N2IifQ.90uebT4-ow1uqZKTUrf6RQ);data file"/>
+  <tag k="locale" v="en-GB"/>
+  <tag k="host" v="https://www.openstreetmap.org/edit"/>
+  <tag k="created_by" v="iD 2.10.0"/>
+  <tag k="comment" v="#hotosm-project-4892;#missingmaps #sh #sho    #short  #salesforce #salesforceleads #salesforcelsUK"/>
+ </changeset>
+</osm>


### PR DESCRIPTION
### Fix for hashtags in comments

* Hashtags were not collected from comments in some cases. Now the same regular expression used in iD is in Underpass to treat most punctuation (except `-, _, +, &`) as hashtag delimiters.
* Hashtag vector on ChangeSet class is now a dictionary, as they're unique

### Update hashtags and updated_at on conflict

* If the Changeset is already present in the DB, `updated_at` and `hashtags` are being updated.

### Test for hashtags

* A test for hashtag was added.

### Remove some debug code and comments

* Some old comments and code for debug was removed.