### PR TITLE
StatsConfig refactor + fix for paths

### DIFF
--- a/data/statsconfig.hh
+++ b/data/statsconfig.hh
@@ -39,16 +39,16 @@
 /// \namespace statsconfig
 namespace statsconfig {
 
-    /// \class StatsConfig
+    /// \class StatsConfigCategory
     /// \brief This class manages configurations for stats collection
-    class StatsConfig {
+    class StatsConfigCategory {
         public:
             std::string name;
             std::map<std::string, std::set<std::string>> way;
             std::map<std::string, std::set<std::string>> node;
             std::map<std::string, std::set<std::string>> relation;
-            StatsConfig(std::string name);
-            StatsConfig
+            StatsConfigCategory(std::string name);
+            StatsConfigCategory
             (
                 std::string name,
                 std::map<std::string, std::set<std::string>> way,
@@ -57,19 +57,19 @@ namespace statsconfig {
             );
     };
 
-    /// \class StatsConfigFile
-    /// \brief This class loads stats configuration files
-    class StatsConfigFile {
+   /// \class StatsConfig
+   /// \brief Stats configuration manager
+   class StatsConfig {
         public:
-            static std::shared_ptr<std::vector<statsconfig::StatsConfig>> read_yaml(std::string filename);
-    };
+            StatsConfig();
+            std::string search(std::string tag, std::string value, osmchange::osmtype_t type);
+            static void setConfigurationFile(std::string statsConfigFilename);
+        private:
+            static std::map<std::string, std::shared_ptr<std::vector<StatsConfigCategory>>> cache;
+            static std::string path;
+            bool searchCategory(std::string tag, std::string value, std::map<std::string, std::set<std::string>> tags);
+            std::shared_ptr<std::vector<statsconfig::StatsConfigCategory>> read_yaml(std::string filename);
 
-   /// \class StatsConfigSearch
-   /// \brief Stats category matching
-   class StatsConfigSearch {
-        public:
-            static std::string tag_value(std::string tag, std::string value, osmchange::osmtype_t type, std::shared_ptr<std::vector<StatsConfig>> statsconfig);
-            static bool category(std::string tag, std::string value, std::map<std::string, std::set<std::string>> tags);
     };
 
 } // EOF statsconfig namespace

--- a/doc/statistics.md
+++ b/doc/statistics.md
@@ -181,7 +181,7 @@ data is parsed from the respective data formats, it gets passed to the
 method. That method loops through the data structure containing the
 changes to the map data. Within that method, it calls
 [ChangeSetFile::scanTags()](https://hotosm.github.io/underpass/classosmchange_1_1OsmChangeFile.html),
-    which does all the real work. The *scanTags()* method uses [StatsConfigSearch::tag_value()](https://hotosm.github.io/underpass/classstatsconfig_1_1StatsConfigSearch.html) to
+    which does all the real work. The *scanTags()* method uses [StatsConfigSearch::search()](https://hotosm.github.io/underpass/classstatsconfig_1_1StatsConfigSearch.html) to
     search the lists of keywords and values configured at the stats configuration file.
 ScanTags() returns an array of statistics for the desired features.
 That array is then converted by collectStats() into the [statistics data

--- a/galaxy/osmchange.cc
+++ b/galaxy/osmchange.cc
@@ -675,24 +675,17 @@ OsmChangeFile::collectStats(const multipolygon_t &poly)
 std::shared_ptr<std::vector<std::string>>
 OsmChangeFile::scanTags(std::map<std::string, std::string> tags, osmchange::osmtype_t type)
 {
-
-    statsconfig::StatsConfigFile statsconfigfile;
-    std::string path = SRCDIR;
-    path += statsConfigFilename;
-    std::shared_ptr<std::vector<statsconfig::StatsConfig>> statsconfig = statsconfigfile.read_yaml(path);
+    auto statsconfig = statsconfig::StatsConfig();
     auto hits = std::make_shared<std::vector<std::string>>();
-
-    std::map<std::string, bool> cache;
-    statsconfig::StatsConfigSearch search;
     for (auto it = std::begin(tags); it != std::end(tags); ++it) {
         if (!it->second.empty()) {
             std::string hit = "";
             if (type == node) {
-                hit = search.tag_value(it->first, it->second, node, statsconfig);
+                hit = statsconfig.search(it->first, it->second, node);
             } else if (type == way) {
-                hit = search.tag_value(it->first, it->second, way, statsconfig);
+                hit = statsconfig.search(it->first, it->second, way);
             } else if (type == relation) {
-                hit = search.tag_value(it->first, it->second, relation, statsconfig);
+                hit = statsconfig.search(it->first, it->second, relation);
             }
             if (!hit.empty()) {
                 hits->push_back(hit);
@@ -723,11 +716,6 @@ ChangeStats::dump(void)
     //     std::cerr << "\t\t" << it->first << " = " << it->second << std::endl;
     // }
 };
-
-void
-OsmChangeFile::setStatsConfigFilename(std::string filename) {
-    statsConfigFilename = filename;
-}
 
 std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>>
 OsmChangeFile::validateNodes(const multipolygon_t &poly, std::shared_ptr<Validate> &plugin)

--- a/galaxy/osmchange.hh
+++ b/galaxy/osmchange.hh
@@ -239,8 +239,6 @@ class OsmChangeFile
         readChanges(osc);
     };
 
-    std::string statsConfigFilename = "/validate/statistics.yaml";
-
     /// Read a changeset file from disk or memory into internal storage
     bool readChanges(const std::string &osc);
 
@@ -255,8 +253,6 @@ class OsmChangeFile
 
     /// Read an istream of the data and parse the XML
     bool readXML(std::istream &xml);
-
-    void setStatsConfigFilename(std::string filename);
 
     std::map<long, std::shared_ptr<ChangeStats>> userstats; ///< User statistics for this file
 

--- a/testsuite/libunderpass.all/stats-test.cc
+++ b/testsuite/libunderpass.all/stats-test.cc
@@ -29,6 +29,7 @@
 #include "data/yaml.hh"
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include <boost/date_time.hpp>
+#include "data/statsconfig.hh"
 namespace opts = boost::program_options;
 
 using namespace boost::posix_time;
@@ -110,7 +111,6 @@ class TestStats {
 
             while (--increment) {
                 osmchange::OsmChangeFile change;
-                change.setStatsConfigFilename(statsConfigFile);
                 if (boost::filesystem::exists(osmchange->filespec)) {
                     change.readChanges(osmchange->filespec);
                 } else {
@@ -137,7 +137,6 @@ class TestStats {
         std::shared_ptr<std::map<long, std::shared_ptr<osmchange::ChangeStats>>>
         getStatsFromFile(std::string filename) {
             osmchange::OsmChangeFile osmchanges;
-            osmchanges.setStatsConfigFilename(statsConfigFile);
             osmchanges.readChanges(filename);
             osmchanges.areaFilter(boundary);
             if (this->verbose) {
@@ -282,7 +281,8 @@ main(int argc, char *argv[]) {
         testStats.startTime = from_iso_extended_string(vm["timestamp"].as<std::string>());
     }
     if (vm.count("statsconfigfile")) {
-        testStats.statsConfigFile = vm["statsconfigfile"].as<std::string>();
+        statsconfig::StatsConfig::setConfigurationFile(vm["statsconfigfile"].as<std::string>());
+
     }
     if (vm.count("verbose")) {
         testStats.verbose = true;

--- a/testsuite/libunderpass.all/statsconfig-test.cc
+++ b/testsuite/libunderpass.all/statsconfig-test.cc
@@ -43,51 +43,37 @@ main(int argc, char *argv[])
     dbglogfile.setWriteDisk(true);
     dbglogfile.setLogFilename("statsconfig-test.log");
     dbglogfile.setVerbosity(3);
+    statsconfig::StatsConfig::setConfigurationFile("../testsuite/testdata/stats/statsconfig.yaml");
+    auto statsconfig = statsconfig::StatsConfig();
 
-    statsconfig::StatsConfigFile statsconfigfile;
-    std::string filename = DATADIR;
-    filename += "/testsuite/testdata/stats/statsconfig.yaml";
-    std::shared_ptr<std::vector<statsconfig::StatsConfig>> statsconfig = statsconfigfile.read_yaml(filename);
-
-    if (
-        statsconfig->at(0).way.count("building") && statsconfig->at(0).way.at("building").count("school") != 0 &&
-        statsconfig->at(1).node.count("amenity") && statsconfig->at(1).node.at("amenity").count("emergency") != 0 &&
-        statsconfig->at(2).way.count("highway") && statsconfig->at(2).way.at("highway").count("yes") != 0
-    ) {
-        runtest.pass("StatsConfigFile::read_yaml()");
+    if (statsconfig.search("building", "school", osmchange::way) == "buildings") {
+        runtest.pass("StatsConfigSearch::search()");
     } else {
-        runtest.fail("StatsConfigFile::read_yaml()");
+        runtest.fail("StatsConfigSearch::search()");
     }
 
-    statsconfig::StatsConfigSearch search;
-    if (search.tag_value("building", "school", osmchange::way, statsconfig) == "buildings") {
-        runtest.pass("StatsConfigSearch::tag_value()");
+    if (statsconfig.search("underpass_tag", "underpass_test", osmchange::way) == "buildings") {
+        runtest.pass("StatsConfigSearch::search() - way custom tags");
     } else {
-        runtest.fail("StatsConfigSearch::tag_value()");
+        runtest.fail("StatsConfigSearch::search() - way custom tags");
     }
 
-    if (search.tag_value("underpass_tag", "underpass_test", osmchange::way, statsconfig) == "buildings") {
-        runtest.pass("StatsConfigSearch::tag_value() - way custom tags");
+    if (statsconfig.search("underpass_tag", "underpass_test", osmchange::node) == "buildings") {
+        runtest.pass("StatsConfigSearch::search() - node custom tags");
     } else {
-        runtest.fail("StatsConfigSearch::tag_value() - way custom tags");
+        runtest.fail("StatsConfigSearch::search() - node custom tags");
     }
 
-    if (search.tag_value("underpass_tag", "underpass_test", osmchange::node, statsconfig) == "buildings") {
-        runtest.pass("StatsConfigSearch::tag_value() - node custom tags");
+    if (statsconfig.search("underpass_tag2", "underpass_test", osmchange::node) == "underpass_category") {
+        runtest.pass("StatsConfigSearch::search() - node custom tags and custom category");
     } else {
-        runtest.fail("StatsConfigSearch::tag_value() - node custom tags");
+        runtest.fail("StatsConfigSearch::search() - node custom tags and custom category");
     }
 
-    if (search.tag_value("underpass_tag2", "underpass_test", osmchange::node, statsconfig) == "underpass_category") {
-        runtest.pass("StatsConfigSearch::tag_value() - node custom tags and custom category");
+    if (statsconfig.search("underpass_tag2", "underpass_test", osmchange::way) == "underpass_category") {
+        runtest.pass("StatsConfigSearch::search() - way custom tags and custom category");
     } else {
-        runtest.fail("StatsConfigSearch::tag_value() - node custom tags and custom category");
-    }
-
-    if (search.tag_value("underpass_tag2", "underpass_test", osmchange::way, statsconfig) == "underpass_category") {
-        runtest.pass("StatsConfigSearch::tag_value() - way custom tags and custom category");
-    } else {
-        runtest.fail("StatsConfigSearch::tag_value() - way custom tags and custom category");
+        runtest.fail("StatsConfigSearch::search() - way custom tags and custom category");
     }
 
 }


### PR DESCRIPTION
### StatsConfig refactor + fix for paths

* Moved logic from StatsConfigFile and StatsConfigSearch to the same class StatsConfig
* Changed the way the configuration file is set, using a static class variable. Now is not necessary to read the YAML file and passing statsconfig as a parameter in osmchange.cc
* StatsConfig now it looks for the configuration file in SRCDIR and, if not found, in PKGLIBDIR, working in the same way that with validation files.
* Relative paths are working better now, and tests for stats were updated following all this changes.