### PR TITLE
Libs and validation config files paths + Fix for _badvalue_ status when there are not values

### DIFF
--- a/data/yaml.cc
+++ b/data/yaml.cc
@@ -198,7 +198,12 @@ bool Node::contains_value(std::string key, std::string value) {
 void Node::contains_value(std::string key, std::string value, bool &result) {
     for (auto it = std::begin(this->children); it != std::end(this->children); ++it) {
         if (it->value == key) {
-            this->contains_key(value, result);
+            for (auto itk = std::begin(it->children); itk != std::end(it->children); ++itk) {
+                if (itk->value == value) {
+                    result = true;
+                    return;
+                }
+            }
             return;
         }
         if (it->children.size() > 0) {

--- a/testsuite/libunderpass.all/test.yaml
+++ b/testsuite/libunderpass.all/test.yaml
@@ -5,7 +5,7 @@ config:
   - maxangle:
     - 91
   - complete:
-    - no
+    - yes
   - values:
     - yes
 

--- a/testsuite/libunderpass.all/yaml-test.cc
+++ b/testsuite/libunderpass.all/yaml-test.cc
@@ -54,7 +54,12 @@ main(int argc, char *argv[])
         runtest.fail("Yaml::get().children");
     }
 
-    if (yaml.get("config").contains_value("complete", "yes")) {
+    if (yaml.contains_value("complete", "yes")) {
+        runtest.pass("Yaml::get().contains_value()");
+    } else {
+        runtest.fail("Yaml::get().contains_value()");
+    }
+    if (!yaml.contains_value("complete", "foo")) {
         runtest.pass("Yaml::get().contains_value()");
     } else {
         runtest.fail("Yaml::get().contains_value()");

--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -141,7 +141,7 @@ Hotosm::checkPOI(const osmobjects::OsmNode &node, const std::string &type)
                 status->status.insert(incomplete);
             }
         }
-        if (tests.contains_value(vit->first, vit->second)) {
+        if (tests.get(vit->first).children.size() == 0 || tests.contains_value(vit->first, vit->second)) {
             // std::cerr << "Matched value: " << vit->second << "\t" << "!" << std::endl;
             valexists++;
             // status->status.insert(correct);

--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -111,23 +111,14 @@ Hotosm::checkPOI(const osmobjects::OsmNode &node, const std::string &type)
     int valexists = 0;
 
     // These values are in the config section of the YAML file
-    bool minimal = false;
-    bool values = false;
+
     // This enables/disables writing features flagged for not being tag complete
     // from being written to the database to reduce the size of the results.
-    if (tests.get("config").contains_value("complete", "yes")) {
-        minimal = false;
-    } else {
-        minimal = true;
-    }
+    bool minimal = tests.get("config").contains_value("complete", "yes");
     // This enables/disables writing features flagged for not having values
     // in range as defined in the YAML config file. This prevents those
     // from being written to the database to reduce the size of the results.
-    if (tests.get("config").contains_value("values", "yes")) {
-        values = true;
-    } else {
-        values = false;
-    }
+    bool values = tests.get("config").contains_value("values", "yes");
 
     for (auto vit = std::begin(node.tags); vit != std::end(node.tags); ++vit) {
         if (node.action == osmobjects::remove) {
@@ -141,7 +132,8 @@ Hotosm::checkPOI(const osmobjects::OsmNode &node, const std::string &type)
                 status->status.insert(incomplete);
             }
         }
-        if (tests.get(vit->first).children.size() == 0 || tests.contains_value(vit->first, vit->second)) {
+
+        if (tests.contains_value(vit->first, vit->second) || (tests.contains_key(vit->first) && tests.get(vit->first).children.size() == 0)) {
             // std::cerr << "Matched value: " << vit->second << "\t" << "!" << std::endl;
             valexists++;
             // status->status.insert(correct);
@@ -202,8 +194,6 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
     // These values are in the config section of the YAML file
     double maxangle = 91;
     double minangle = 85;
-    bool minimal = false;
-    bool values = false;
     auto config = tests.get("config");
 
     // This is the minimum angle used to determine rectangular buildings
@@ -218,21 +208,12 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
     }
     // This enables/disables writing features flagged for not being tag complete
     // from being written to the database to reduce the size of the results.
-    auto configComplete = config.get("complete");
-    if (configComplete.children.size() > 0 && configComplete.children[0].value == "yes") {
-        minimal = false;
-    } else {
-        minimal = true;
-    }
+    bool minimal = tests.get("config").contains_value("complete", "yes");
     // This enables/disables writing features flagged for not having values
     // in range as defined in the YAML config file. This prevents those
     // from being written to the database to reduce the size of the results.
-    auto configValues = config.get("values");
-    if (configValues.children.size() > 0 && configValues.children[0].value == "yes") {
-        values = true;
-    } else {
-        values = false;
-    }
+    bool values = tests.get("config").contains_value("values", "yes");
+
     for (auto vit = std::begin(way.tags); vit != std::end(way.tags); ++vit) {
         if (way.action == osmobjects::remove) {
             continue;
@@ -246,7 +227,7 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
             }
             continue;
         }
-        if (tests.contains_value(vit->first, vit->second)) {
+        if (tests.contains_value(vit->first, vit->second) || (tests.contains_key(vit->first) && tests.get(vit->first).children.size() == 0)) {
             // std::cerr << "Matched value: " << vit->second << "\t" << "!" << std::endl;
             valexists++;
             // status->status.insert(correct);
@@ -260,7 +241,19 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
                 status->status.insert(badvalue);
             }
         }
-
+        if (keyexists == tests.get("tags").children.size() && valexists == tests.get("tags").children.size()) {
+            status->status.clear();
+            if (!minimal) {
+                status->status.insert(complete);
+            }
+        } else {
+            if (!minimal) {
+                status->status.insert(incomplete);
+            }
+        }
+        if (status->status.size() == 0) {
+            status->status.insert(correct);
+        }
         if (way.linestring.size() == 0) {
             return status;
         }
@@ -293,19 +286,7 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
         }
         return status;
     }
-    if (keyexists == tests.get("tags").children.size() && valexists == tests.get("tags").children.size()) {
-        status->status.clear();
-        if (!minimal) {
-            status->status.insert(complete);
-        }
-    } else {
-        if (!minimal) {
-            status->status.insert(incomplete);
-        }
-    }
-    if (status->status.size() == 0) {
-        // status->status.insert(correct);
-    }
+
     return status;
 }
 

--- a/validate/validate.hh
+++ b/validate/validate.hh
@@ -168,7 +168,9 @@ class BOOST_SYMBOL_VISIBLE Validate {
   public:
     Validate(void) {
         std::string dir = SRCDIR;
-        if (!boost::filesystem::exists(dir)) {
+        if (boost::filesystem::exists("../validate")) {
+            dir = "../validate";
+        } else if (!boost::filesystem::exists("../validate") && !boost::filesystem::exists(dir)) {
             dir = PKGLIBDIR;
             if (!boost::filesystem::exists(dir)) {
                 log_error(_("No validation config files in %1%!"), dir);
@@ -190,7 +192,7 @@ class BOOST_SYMBOL_VISIBLE Validate {
         yaml::Yaml yaml;
         yaml.read(filespec);
         if (!config.stem().empty()) {
-        yamls[config.stem()] = yaml;
+            yamls[config.stem()] = yaml;
         }
     }
 #endif


### PR DESCRIPTION
* If there are no values specified in the validation YAML config file (ex: building:levels), do not return _badvalue_ status
* Look for libs and validation YAML config files in paths relative to the build folder first
* Yaml::Node contains_value() was not working good, returning true even if the value was not present, its fixed now.
* Test for validation is fixed and commented
* Test for Yaml is updated