### PR TITLE
Updated SQL query for clean the validation table when using --osmnoboundary

### DIFF
--- a/data/clean-osmchanges.sql
+++ b/data/clean-osmchanges.sql
@@ -6,4 +6,12 @@ We run this query every 24 hours for cleaning the database
 when running the replicator process with areaFilter disabled 
 for osmchanges (--osmnoboundary).
 */
-DELETE FROM changesets WHERE bbox is null and closed_at < NOW() - INTERVAL '24 HOURS' RETURNING id;
+DELETE FROM validation v where v.change_id in (
+	SELECT id from changesets
+	WHERE bbox is NULL
+	AND closed_at < NOW() - INTERVAL '24 HOURS'
+);
+
+DELETE FROM changesets WHERE
+    bbox is NULL
+    AND closed_at < NOW() - INTERVAL '24 HOURS';


### PR DESCRIPTION
This PR adds a cleaning query for validation table too.

Background: when `--osmnoboundary` option is used, the priority boundary is ignored for OsmChanges, enabling Underpass to include stats and validation for changes with no coordinates. Then, a cron job that runs `data/clean-osmchanges.sql` can be used to clean the changesets table, deleting all entries without bbox (as changesets are still filtered).