### PR TITLE
+ Add source for validation status

### DIFF
--- a/data/galaxy.sql
+++ b/data/galaxy.sql
@@ -50,6 +50,7 @@ CREATE TABLE public.validation (
     angle double precision,
     status public.status[],
     values text[],
+    source text,
     timestamp timestamp with time zone,
     location public.geometry(Geometry,4326)
 );

--- a/galaxy/galaxy.cc
+++ b/galaxy/galaxy.cc
@@ -364,8 +364,8 @@ QueryGalaxy::applyChange(const ValidateStatus &validation) const
     std::string format;
     std::string query;
     if (validation.values.size() > 0) {
-        query = "INSERT INTO validation (osm_id, change_id, angle, user_id, type, status, values, timestamp, location) VALUES(";
-        format = "%d, %d, %g, %d, \'%s\', ARRAY[%s]::status[], ARRAY[%s], \'%s\', ST_GeomFromText(\'%s\', 4326)";
+        query = "INSERT INTO validation (osm_id, change_id, angle, user_id, type, status, values, timestamp, location, source) VALUES(";
+        format = "%d, %d, %g, %d, \'%s\', ARRAY[%s]::status[], ARRAY[%s], \'%s\', ST_GeomFromText(\'%s\', 4326), \'%s\'";
     } else {
         query = "INSERT INTO validation (osm_id, change_id, angle, user_id, type, status, timestamp, location) VALUES(";
         format = "%d, %d, %g, %d, \'%s\', ARRAY[%s]::status[], \'%s\', ST_GeomFromText(\'%s\', 4326)";
@@ -401,11 +401,14 @@ QueryGalaxy::applyChange(const ValidateStatus &validation) const
     // Postgres wants the order of lat,lon reversed from how they
     // are stored in the WKT.
     fmt % boost::geometry::wkt(validation.center);
+    if (validation.values.size() > 0) {
+        fmt % validation.source;
+    }
     query += fmt.str();
     query += ") ON CONFLICT (osm_id) DO UPDATE ";
     query += " SET status = ARRAY[" + stattmp + " ]::status[]";
     if (validation.values.size() > 0) {
-        query += ", values = ARRAY[" + valtmp + " ]";
+        query += ", values = ARRAY[" + valtmp + " ], source = \'" + validation.source + "\'";
     }
 //    log_debug(_("QUERY: %1%"), query);
 

--- a/galaxy/osmchange.cc
+++ b/galaxy/osmchange.cc
@@ -798,6 +798,7 @@ OsmChangeFile::validateWays(const multipolygon_t &poly, std::shared_ptr<Validate
                     }
                 }
                 if (status->status.size() > 0) {
+                    status->source = *wit;
                     totals->push_back(status);
                 }
             }

--- a/validate/validate.hh
+++ b/validate/validate.hh
@@ -163,6 +163,7 @@ class ValidateStatus {
     point_t center;        ///< The centroid of the building polygon
     double angle = 0;        ///< The calculated angle of a corner
     std::unordered_set<std::string> values; ///< The found bad tag values
+    std::string source; //< The source of the validation status
 };
 
 


### PR DESCRIPTION
Added a new "source" column for identifying where the validation is coming from.

This enables an improved reporting:

<img width="504" alt="Screen Shot 2022-11-16 at 22 43 23" src="https://user-images.githubusercontent.com/1226194/202333406-4ae236df-bb7b-499f-af81-3b131eb5590c.png">

