### PR TITLE
Replaced angle measurement with azimuth of opposing sides

### DIFF
--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -252,32 +252,30 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
     if (way.refs.front() == way.refs.back()) {
 
         // If it's a building, check for square corners
-        // FIXME: move out special cases to the config file
-        if (way.tags.count("building")) {
-            if (boost::geometry::num_points(way.linestring) < 3 && way.action == osmobjects::modify) {
-                log_debug(_("Not enough nodes in modified linestring to calculate the angle!"));
-                return status;
+
+        if (way.tags.count("building") && way.refs.size() == 5) {
+
+            if (!polygonHasPairsOfParallelSides(way.linestring)) {
+                status->status.insert(badgeom);
             }
 
+            // FIXME: angle calculation needs a close review
             // minangle, maxangle, circle
-            std::tuple<double, double, bool> angles = cornerAngle(way.linestring);
 
-            if (std::get<2>(angles)) {
-                if (way.linestring.size() - 1 < circleMinPoints) {
-                    status->angle = std::get<0>(angles);
-                    status->status.insert(badgeom);
-                }
-            } else if (std::get<0>(angles) > maxangle) {
-                status->angle = std::get<1>(angles);
-                status->status.insert(badgeom);
-            } else if (std::get<1>(angles) < minangle) {
-                status->angle = std::get<0>(angles);
-                status->status.insert(badgeom);
-            }
-        } else if (way.refs.size() == 5 && way.tags.size() == 0) {
-            // See if it's closed, has 4 corners, but no tags
-            // FIXME: move out special cases to the config file
-            log_error(_("WARNING: %1% might be a building!"), way.id);
+            // std::tuple<double, double, bool> angles = cornerAngles(way.linestring);
+            // log_error(_("Angle max: %1% min: %2%"), std::get<0>(angles), std::get<1>(angles));
+            // if (std::get<2>(angles)) {
+            //     if (way.linestring.size() - 1 < circleMinPoints) {
+            //         status->angle = std::get<0>(angles);
+            //         status->status.insert(badgeom);
+            //     }
+            // } else if (std::get<0>(angles) > maxangle) {
+            //     status->angle = std::get<0>(angles);
+            //     status->status.insert(badgeom);
+            // } else if (std::get<1>(angles) < minangle) {
+            //     status->angle = std::get<1>(angles);
+            //     status->status.insert(badgeom);
+            // }
         }
     }
     if (status->status.size() == 0) {

--- a/validate/validate.hh
+++ b/validate/validate.hh
@@ -295,22 +295,17 @@ class BOOST_SYMBOL_VISIBLE Validate {
         double ba1 = y1 - y2;
         double bc0 = x3 - x2;
         double bc1 = y3 - y2;
-
         double dot_p = ba0 * bc0 + ba1 * bc1;
-
         double cosine_angle = dot_p / (
             std::pow((ba0 * ba0 + ba1 * ba1) , 0.5) *
             std::pow((bc0 * bc0 + bc1 * bc1) , 0.5)
         );
-
         double angle = acos(cosine_angle);
-
         return angle * 180 / M_PI;
     }
 
     // Checks if a polygon has pairs of parallel sides
     bool polygonHasPairsOfParallelSides(const linestring_t &way) {
-
         double x1 = boost::geometry::get<1>(way[0]);
         double y1 = boost::geometry::get<0>(way[0]);
         double x2 = boost::geometry::get<1>(way[1]);
@@ -319,16 +314,11 @@ class BOOST_SYMBOL_VISIBLE Validate {
         double y3 = boost::geometry::get<0>(way[2]);
         double x4 = boost::geometry::get<1>(way[3]);
         double y4 = boost::geometry::get<0>(way[3]);
-
         double az1 = std::round( calculateAzimuth(x1,y1, x2, y2));
         double az2 = std::round( calculateAzimuth(x2,y2, x3, y3));
         double az3 = std::round( calculateAzimuth(x4,y4, x3, y3));
         double az4 = std::round( calculateAzimuth(x1,y1, x4, y4));
-
-        return(
-            az1 - 5 <= az3 + 5 &&
-            az2 - 5 <= az4 + 5
-        );
+        return(abs(az1 - az3) <= 10 && abs(az2 - az4) <= 10);
     }
 
     std::tuple<double, double, bool> cornerAngles(const linestring_t &way) {


### PR DESCRIPTION
- Angle measurement for identifying bad geometry was replaced with measuring the azimuth of opposing sides. 
- Bad geometry was limited to 4 sides buildings only

These are temporary fixes, as angle measurement is not working as expected, resulting in false positives.

The results now are working very good, as we can see in the POC in which we're currently working on:

<img width="840" alt="Screen Shot 2022-12-29 at 20 01 32" src="https://user-images.githubusercontent.com/1226194/210019253-624857dd-f3a7-4570-b9f5-2f1396c3e4a9.png">
