### PR TITLE
Underpass for Python

### DIFF
--- a/data/yaml.cc
+++ b/data/yaml.cc
@@ -213,7 +213,6 @@ void Node::contains_value(std::string key, std::string value, bool &result) {
 
 void Node::dump() {
     for (auto it = std::begin(this->children); it != std::end(this->children); ++it) {
-        std::cout << it->value << std::endl;
         if (it->children.size() > 0) {
             it->dump();
         }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     #build:
     #  context: .
     #  dockerfile: underpass-build-deps.dockerfile
+    ports:
+      - "5480:8000"
     environment:
       - PGHOST=postgis
       - PGUSER=underpass

--- a/example/validation.py
+++ b/example/validation.py
@@ -1,7 +1,7 @@
-import underpass as u
+from underpass import underpass as u
 import argparse
 
-def validateOsmChange(xml, check):
+def validateOsmChange(xml: str, check: str):
     validator = u.Validate()
     return validator.checkOsmChange(xml, check)
 
@@ -14,9 +14,10 @@ def main():
     if args.file and args.check:
         with open(args.file, 'r') as file:
             data = file.read().rstrip()
-            print(validateOsmChange(data, args.check))
+            # print(validateOsmChange(data, args.check))
+            validateOsmChange(data, args.check)
     else:
         print("Usage: python validaiton.py -f mychange.osm -c building")
-
+        print("Example: python ../example/validation.py -f ../testsuite/testdata/stats/107235440.xml -c highway")
 if __name__ == "__main__":
     main()

--- a/example/validation.py
+++ b/example/validation.py
@@ -1,4 +1,4 @@
-from underpass import underpass as u
+import underpass as u
 import argparse
 
 def validateOsmChange(xml: str, check: str):
@@ -14,10 +14,9 @@ def main():
     if args.file and args.check:
         with open(args.file, 'r') as file:
             data = file.read().rstrip()
-            # print(validateOsmChange(data, args.check))
-            validateOsmChange(data, args.check)
+            print(validateOsmChange(data, args.check))
     else:
         print("Usage: python validaiton.py -f mychange.osm -c building")
-        print("Example: python ../example/validation.py -f ../testsuite/testdata/stats/107235440.xml -c highway")
+        print("Example: python ../example/validation.py -f ../testsuite/testdata/validation/building-tag.osc -c building")
 if __name__ == "__main__":
     main()

--- a/example/validation.py
+++ b/example/validation.py
@@ -16,7 +16,7 @@ def main():
             data = file.read().rstrip()
             print(validateOsmChange(data, args.check))
     else:
-        print("Usage: python validaiton.py -f mychange.osm -c building")
+        print("Usage: python validation.py -f <file> -c <check>")
         print("Example: python ../example/validation.py -f ../testsuite/testdata/validation/building-tag.osc -c building")
 if __name__ == "__main__":
     main()

--- a/testsuite/testdata/validation/building-tag.osc
+++ b/testsuite/testdata/validation/building-tag.osc
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="Osmosis 0.47.4">
+  <create>
+    <node id='-111766' visible='true' lat='4.62042952837' lon='21.72600147299' />
+    <node id='-111767' visible='true' lat='4.62042742837' lon='21.72608657299' />
+    <node id='-111768' visible='true' lat='4.62036492836' lon='21.72608497299' />
+    <node id='-111769' visible='true' lat='4.62036702836' lon='21.72599987299' />
+    <way id='-101874' visible='true'>
+      <nd ref='-111766' />
+      <nd ref='-111767' />
+      <nd ref='-111768' />
+      <nd ref='-111769' />
+      <nd ref='-111766' />
+      <tag k="building" v="yes"/>
+      <tag k="material" v="water"/>
+    </way>
+  </create>
+</osmChange>

--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -186,7 +186,6 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
         return status;
     }
 
-    std::cout << "*** type: " << type << std::endl;
     yaml::Yaml tests = yamls[type];
     tests.dump();
 
@@ -327,7 +326,6 @@ Hotosm::checkOsmChange(const std::string &xml, const std::string &check) {
     osmchange::OsmChangeFile ocf;
     std::stringstream _xml(xml);
     ocf.readXML(_xml);
-    std::cout << "Changes: " << ocf.changes.size() << std::endl;
     std::vector<ValidateStatus> result;
     for (auto it = std::begin(ocf.changes); it != std::end(ocf.changes); ++it) {
         osmchange::OsmChange *change = it->get();

--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -186,7 +186,9 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
         return status;
     }
 
+    std::cout << "*** type: " << type << std::endl;
     yaml::Yaml tests = yamls[type];
+    tests.dump();
 
     std::string key;
     int tagexists = 0;
@@ -325,6 +327,7 @@ Hotosm::checkOsmChange(const std::string &xml, const std::string &check) {
     osmchange::OsmChangeFile ocf;
     std::stringstream _xml(xml);
     ocf.readXML(_xml);
+    std::cout << "Changes: " << ocf.changes.size() << std::endl;
     std::vector<ValidateStatus> result;
     for (auto it = std::begin(ocf.changes); it != std::end(ocf.changes); ++it) {
         osmchange::OsmChange *change = it->get();

--- a/validate/hotosm.cc
+++ b/validate/hotosm.cc
@@ -187,7 +187,6 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
     }
 
     yaml::Yaml tests = yamls[type];
-    tests.dump();
 
     std::string key;
     int tagexists = 0;

--- a/validate/validate.hh
+++ b/validate/validate.hh
@@ -172,8 +172,14 @@ class ValidateStatus {
 class BOOST_SYMBOL_VISIBLE Validate {
   public:
     Validate(void) {
-        std::string dir = SRCDIR;
-        if (boost::filesystem::exists("../validate")) {
+        std::string dir;
+
+        std::cout << "SRCDIR " << SRCDIR << std::endl;
+        std::cout << "PKGLIBDIR " << PKGLIBDIR << std::endl;
+
+        if (boost::filesystem::exists(SRCDIR)) {
+            std::string dir = SRCDIR;
+        } else if (boost::filesystem::exists("../validate")) {
             dir = "../validate";
         } else if (!boost::filesystem::exists("../validate") && !boost::filesystem::exists(dir)) {
             dir = PKGLIBDIR;

--- a/validate/validate.hh
+++ b/validate/validate.hh
@@ -174,18 +174,14 @@ class BOOST_SYMBOL_VISIBLE Validate {
     Validate(void) {
         std::string dir;
 
-        std::cout << "SRCDIR " << SRCDIR << std::endl;
-        std::cout << "PKGLIBDIR " << PKGLIBDIR << std::endl;
-
-        if (boost::filesystem::exists(SRCDIR)) {
-            std::string dir = SRCDIR;
+        if (boost::filesystem::exists(PKGLIBDIR)) {
+            dir = PKGLIBDIR;
+        } else if (boost::filesystem::exists(SRCDIR)) {
+            dir = SRCDIR;
         } else if (boost::filesystem::exists("../validate")) {
             dir = "../validate";
-        } else if (!boost::filesystem::exists("../validate") && !boost::filesystem::exists(dir)) {
-            dir = PKGLIBDIR;
-            if (!boost::filesystem::exists(dir)) {
-                log_error(_("No validation config files in %1%!"), dir);
-            }
+        } else {
+            log_error(_("No validation config files in %1%!"), dir);
         }
         for (auto &file: std::filesystem::recursive_directory_iterator(dir)) {
             std::filesystem::path config = file.path();


### PR DESCRIPTION
- Fixed path search for validation config files
- Added an OSM change for testing validation
- Updated example Python script for validation
- Removed debug lines
- Exposed port on Docker container for testing the Underpass Python module inside a REST API

Now it's possible to run Underpass validation for a OsmChange's XML using Python:

```python
import underpass as u

validator = u.Validate()
result = validator.checkOsmChange(xml, check)
```

Full example at `example/validation.py`.

This module was also tested integrated into another project, currently known as [Galaxy API](https://github.com/hotosm/galaxy-api), for creating an endpoint that receives a OsmChange's XML and returns a JSON with the result of validation.

Request:

```
curl --location 'http://127.0.1:5480/v1/data-quality/validate/osmchange/' \
--header 'Content-Type: application/json' \
--data '{ \
    "osmchange": <OsmChange's XML>, \
    "check": "building" \
}'
```

Response:

```json
[
  {
    "osm_id": -101874,
    "user_id": 0,
    "change_id": 0,
    "angle": 0.0,
    "results": [
      "complete",
      "badvalue"
    ],
    "values": [
      "material=water"
    ]
  }
]
```
