### PR TITLE
Fixes for coordinates precision

### DIFF
--- a/src/osm/osmchange.cc
+++ b/src/osm/osmchange.cc
@@ -208,6 +208,7 @@ OsmChangeFile::readXML(std::istream &xml)
             if (child.first == "node") {
                 double lat = value.second.get("<xmlattr>.lat", 0.0);
                 double lon = value.second.get("<xmlattr>.lon", 0.0);
+
                 auto object = std::make_shared<OsmNode>();
                 object->setLatitude(lat);
                 object->setLongitude(lon);

--- a/src/osm/osmchange.hh
+++ b/src/osm/osmchange.hh
@@ -257,7 +257,7 @@ class OsmChangeFile
     std::map<long, std::shared_ptr<ChangeStats>> userstats; ///< User statistics for this file
 
     std::list<std::shared_ptr<OsmChange>> changes; ///< All the changes in this file
-    std::map<long, point_t> nodecache;           ///< Cache nodes across multiple changesets
+    std::map<double, point_t> nodecache;           ///< Cache nodes across multiple changesets
 
     /// Collect statistics for each user
     std::shared_ptr<std::map<long, std::shared_ptr<ChangeStats>>>

--- a/src/osm/osmobjects.hh
+++ b/src/osm/osmobjects.hh
@@ -35,6 +35,9 @@ using namespace boost::posix_time;
 using namespace boost::gregorian;
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
 
+#include "utils/log.hh"
+using namespace logger;
+
 typedef boost::geometry::model::d2::point_xy<double> point_t;
 typedef boost::geometry::model::polygon<point_t> polygon_t;
 typedef boost::geometry::model::multi_polygon<polygon_t> multipolygon_t;
@@ -114,9 +117,13 @@ class OsmNode : public OsmObject {
         type = node;
     };
     /// Set the latitude of this node
-    void setLatitude(double lat) { point.set<1>(lat); };
+    void setLatitude(double lat) {
+        point.set<1>(lat);
+    };
     /// Set the longitude of this node
-    void setLongitude(double lon) { point.set<0>(lon); };
+    void setLongitude(double lon) {
+        point.set<0>(lon);
+    };
     /// Set the location of this node
     void setPoint(double lat, double lon)
     {

--- a/src/raw/queryraw.cc
+++ b/src/raw/queryraw.cc
@@ -74,9 +74,13 @@ QueryRaw::applyChange(const OsmNode &node) const
         fmt % node.id;
         // change_id
         fmt % node.change_id;
+
         // geometry
-        auto geometry = boost::geometry::wkt(node.point);
+        std::stringstream ss;
+        ss << std::setprecision(12) << boost::geometry::wkt(node.point);
+        std::string geometry = ss.str();
         fmt % geometry;
+
         // tags
         std::string tags = "";
         if (node.tags.size() > 0) {

--- a/src/validate/hotosm.cc
+++ b/src/validate/hotosm.cc
@@ -256,10 +256,7 @@ Hotosm::checkWay(const osmobjects::OsmWay &way, const std::string &type)
         status->status.insert(incomplete);
     }
 #endif
-    // FIXME: centroid is not always correct
-    // boost::geometry::centroid(way.polygon, status->center);
-    // boost::geometry::centroid(way.linestring, status->center);
-    status->center = way.linestring[0];
+    boost::geometry::centroid(way.linestring, status->center);
     // See if the way is a closed polygon
     if (way.action == osmobjects::create && way.refs.front() == way.refs.back()) {
         // If it's a building, check for square corners

--- a/src/validate/queryvalidate.cc
+++ b/src/validate/queryvalidate.cc
@@ -144,9 +144,12 @@ QueryValidate::applyChange(const ValidateStatus &validation) const
         fmt % valtmp;
     }
     fmt % to_simple_string(validation.timestamp);
-    // Postgres wants the order of lat,lon reversed from how they
-    // are stored in the WKT.
-    fmt % boost::geometry::wkt(validation.center);
+
+    std::stringstream ss;
+    ss << std::setprecision(12) << boost::geometry::wkt(validation.center);
+    std::string center = ss.str();
+    fmt % center;
+
     if (validation.values.size() > 0) {
         fmt % validation.source;
     }


### PR DESCRIPTION
Precision for coordinates saved into the database were 4 decimal digits only. 

This PR fix that, allowing 12 decimal digits.