### PR TITLE
Make /etc configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -156,11 +156,8 @@ install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(ETCDIR)
 	cp -rvp $(srcdir)/config/priority.geojson  $(DESTDIR)$(ETCDIR)/
 	cp -rvp $(srcdir)/config/replicator  $(DESTDIR)$(ETCDIR)/
-	cp -rvp $(srcdir)/config/validate  $(DESTDIR)$(ETCDIR)/
 	cp -rvp $(srcdir)/config/stats  $(DESTDIR)$(ETCDIR)/
 	cp -rvp $(srcdir)/config/default.yaml  $(DESTDIR)$(ETCDIR)/
-	$(MKDIR_P) $(DESTDIR)/$(docdir)
-	cp -rvp $(srcdir)/docs/*.md $(DESTDIR)/$(docdir)
 	cp -rvp $(srcdir)/setup/service $(DESTDIR)/$(pkglibdir)
 	$(MKDIR_P) $(DESTDIR)$(pkglibdir)/../system
 	cp -rvp $(srcdir)/setup/service/underpass.service  $(DESTDIR)$(pkglibdir)/../system/
@@ -182,20 +179,20 @@ PCHFLAGS = \
         -I$(top_builddir) \
         -I$(top_srcdir)/src \
         -I$(top_srcdir)/src/stats \
-		-I$(top_srcdir)/src/validate \
+	-I$(top_srcdir)/src/validate \
         -I$(top_srcdir)/src/data
 
 PCHHEADERS = \
         $(top_srcdir)/src/replicator/planetreplicator.hh \
         $(top_srcdir)/src/stats/querystats.hh \
-		$(top_srcdir)/src/raw/queryraw.hh \
+	$(top_srcdir)/src/raw/queryraw.hh \
         $(top_srcdir)/src/replicator/replication.hh \
         $(top_srcdir)/src/osm/osmchange.hh \
         $(top_srcdir)/src/osm/changeset.hh \
         $(top_srcdir)/src/osm/osmobjects.hh \
         $(top_srcdir)/src/validate/validate.hh \
         $(top_srcdir)/src/utils/geoutil.hh \
-		$(top_srcdir)/src/utils/geo.hh \
+	$(top_srcdir)/src/utils/geo.hh \
         $(top_srcdir)/src/replicator/threads.hh
 
 PCHOTHER = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -92,8 +92,7 @@ AM_CXXFLAGS = \
 	-fno-builtin-malloc \
 	-fno-builtin-calloc \
 	-fno-builtin-realloc \
-	-fno-builtin-free \
-	-DETCDIR=$(ETCDIR)
+	-fno-builtin-free
 else
 AM_CXXFLAGS = \
 	-rdynamic \
@@ -104,6 +103,7 @@ endif
 AM_CPPFLAGS = \
 	-DPKGLIBDIR=\"$(pkglibdir)\" \
 	-DSRCDIR=\"$(srcdir)\" \
+	-DETCDIR=\"$(ETCDIR)\" \
 	-DBOOST_LOCALE_HIDE_AUTO_PTR
 # Optionally timing can be turned on, which produces volumes of output which adds too much
 # clutter to the output. This should only be enabled when doing performance tuning.

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ CLEANFILES = \
 
 DISTCLEANFILES = docs/html docs/latex .lastmod
 MAINTAINERCLEANFILES = revno.h .lastmod
+ETCDIR = $(subst lib,etc,$(pkglibdir))
 
 SUBDIRS = \
 	src/validate
@@ -91,7 +92,8 @@ AM_CXXFLAGS = \
 	-fno-builtin-malloc \
 	-fno-builtin-calloc \
 	-fno-builtin-realloc \
-	-fno-builtin-free
+	-fno-builtin-free \
+	-DETCDIR=$(ETCDIR)
 else
 AM_CXXFLAGS = \
 	-rdynamic \
@@ -119,7 +121,7 @@ EXTRA_DIST = \
 	dist/debian \
 	dist/redhat \
 	utils
-	
+
 
 DEJATOOL = libunderpass
 
@@ -151,17 +153,17 @@ apidoc:
 endif
 
 install-data-hook:
-	$(MKDIR_P) $(DESTDIR)/$(pkglibdir)
-	$(MKDIR_P) /etc/underpass
-	cp -rvp $(srcdir)/config/priority.geojson /etc/underpass/
-	cp -rvp $(srcdir)/config/replicator /etc/underpass/
-	cp -rvp $(srcdir)/config/validate /etc/underpass/
-	cp -rvp $(srcdir)/config/stats /etc/underpass/
-	cp -rvp $(srcdir)/config/default.yaml /etc/underpass/
+	$(MKDIR_P) $(DESTDIR)$(ETCDIR)
+	cp -rvp $(srcdir)/config/priority.geojson  $(DESTDIR)$(ETCDIR)/
+	cp -rvp $(srcdir)/config/replicator  $(DESTDIR)$(ETCDIR)/
+	cp -rvp $(srcdir)/config/validate  $(DESTDIR)$(ETCDIR)/
+	cp -rvp $(srcdir)/config/stats  $(DESTDIR)$(ETCDIR)/
+	cp -rvp $(srcdir)/config/default.yaml  $(DESTDIR)$(ETCDIR)/
 	$(MKDIR_P) $(DESTDIR)/$(docdir)
 	cp -rvp $(srcdir)/docs/*.md $(DESTDIR)/$(docdir)
 	cp -rvp $(srcdir)/setup/service $(DESTDIR)/$(pkglibdir)
-	cp -rvp $(srcdir)/setup/service/underpass.service /etc/systemd/system/
+	$(MKDIR_P) $(DESTDIR)$(pkglibdir)/../system
+	cp -rvp $(srcdir)/setup/service/underpass.service  $(DESTDIR)$(pkglibdir)/../system/
 
 dist-hook: apidoc
 	$(MKDIR_P) $(DESTDIR)/$(docdir)

--- a/src/replicator/planetreplicator.cc
+++ b/src/replicator/planetreplicator.cc
@@ -102,7 +102,8 @@ PlanetReplicator::PlanetReplicator(void) {};
 std::shared_ptr<RemoteURL> PlanetReplicator::findRemotePath(const underpassconfig::UnderpassConfig &config, ptime time) {
     yaml::Yaml yaml;
 
-    std::string rep_file = "ETCDIR/replicator/planetreplicator.yaml";
+    std::string rep_file = ETCDIR;
+    rep_file += "replicator/planetreplicator.yaml";
     yaml.read(rep_file);
     std::map<int, ptime> hashes;
 

--- a/src/replicator/planetreplicator.cc
+++ b/src/replicator/planetreplicator.cc
@@ -102,7 +102,7 @@ PlanetReplicator::PlanetReplicator(void) {};
 std::shared_ptr<RemoteURL> PlanetReplicator::findRemotePath(const underpassconfig::UnderpassConfig &config, ptime time) {
     yaml::Yaml yaml;
 
-    std::string rep_file = "/etc/underpass/replicator/planetreplicator.yaml";
+    std::string rep_file = "ETCDIR/replicator/planetreplicator.yaml";
     yaml.read(rep_file);
     std::map<int, ptime> hashes;
 

--- a/src/replicator/planetreplicator.cc
+++ b/src/replicator/planetreplicator.cc
@@ -103,7 +103,7 @@ std::shared_ptr<RemoteURL> PlanetReplicator::findRemotePath(const underpassconfi
     yaml::Yaml yaml;
 
     std::string rep_file = ETCDIR;
-    rep_file += "replicator/planetreplicator.yaml";
+    rep_file += "/replicator/planetreplicator.yaml";
     yaml.read(rep_file);
     std::map<int, ptime> hashes;
 

--- a/src/stats/statsconfig.cc
+++ b/src/stats/statsconfig.cc
@@ -51,7 +51,8 @@ namespace statsconfig {
 
     StatsConfig::StatsConfig() {
         if (path.empty()) {
-            path = "ETCDIR/stats/statistics.yaml";
+            path = ETCDIR;
+            path += "/stats/statistics.yaml";
             if (!boost::filesystem::exists(path)) {
                 throw std::runtime_error("Statistics file not found: " + path);
             }

--- a/src/stats/statsconfig.cc
+++ b/src/stats/statsconfig.cc
@@ -51,7 +51,7 @@ namespace statsconfig {
 
     StatsConfig::StatsConfig() {
         if (path.empty()) {
-            path = "/etc/underpass/stats/statistics.yaml";
+            path = "ETCDIR/stats/statistics.yaml";
             if (!boost::filesystem::exists(path)) {
                 throw std::runtime_error("Statistics file not found: " + path);
             }

--- a/src/testsuite/libunderpass.all/Makefile.am
+++ b/src/testsuite/libunderpass.all/Makefile.am
@@ -19,6 +19,8 @@
 
 AUTOMAKE_OPTIONS = dejagnu
 
+ETCDIR = $(subst lib,etc,$(pkglibdir))
+
 check_PROGRAMS = \
 	pq-test \
 	change-test \
@@ -55,6 +57,7 @@ AM_CXXFLAGS = \
         -DPKGLIBDIR=\"$(pkglibdir)\" \
         -DTOPSRCDIR=\"$(TOPSRC)\" \
         -DSRCDIR=\"$(srcdir)\" \
+	 -DETCDIR=\"$(ETCDIR)\" \
 	-DBOOST_LOCALE_HIDE_AUTO_PTR \
 	-Wno-deprecated-declarations
 

--- a/src/testsuite/libunderpass.all/geo-test.cc
+++ b/src/testsuite/libunderpass.all/geo-test.cc
@@ -61,7 +61,7 @@ main(int argc, char* argv[])
         return 1;
     }
 
-    if (tgu.readFile("/etc/underpass/priority.geojson")) {
+    if (tgu.readFile("ETCDIR/priority.geojson")) {
         runtest.pass("Read file with absolute path");
     } else {
         runtest.fail("Read file with absolute path");

--- a/src/testsuite/libunderpass.all/geo-test.cc
+++ b/src/testsuite/libunderpass.all/geo-test.cc
@@ -61,7 +61,9 @@ main(int argc, char* argv[])
         return 1;
     }
 
-    if (tgu.readFile("ETCDIR/priority.geojson")) {
+    std::string filespec = ETCDIR;
+    filespec += "/priority.geojson";
+    if (tgu.readFile(filespec)) {
         runtest.pass("Read file with absolute path");
     } else {
         runtest.fail("Read file with absolute path");

--- a/src/underpass.cc
+++ b/src/underpass.cc
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
 {
 
     std::string datadir = "replication/";
-    std::string boundary = "/etc/underpass/priority.geojson";
+    std::string boundary = "ETCDIR/priority.geojson";
 
     UnderpassConfig config;
 

--- a/src/underpass.cc
+++ b/src/underpass.cc
@@ -85,7 +85,8 @@ main(int argc, char *argv[])
 {
 
     std::string datadir = "replication/";
-    std::string boundary = "ETCDIR/priority.geojson";
+    std::string boundary = ETCDIR;
+    boundary += "/priority.geojson";
 
     UnderpassConfig config;
 

--- a/src/underpassconfig.hh
+++ b/src/underpassconfig.hh
@@ -103,9 +103,11 @@ struct UnderpassConfig {
     UnderpassConfig()
     {
 
-        if (std::filesystem::exists("/etc/underpass/default.yaml")) {
+        std::string filespec = ETCDIR;
+        filespec += "default.yaml";
+        if (std::filesystem::exists(filespec)) {
             yaml::Yaml yaml;
-            yaml.read("/etc/underpass/default.yaml");
+            yaml.read(filespec);
             auto yamlConfig = yaml.get("config");
             if (yaml.contains_key("underpass_db_url")) {
                 underpass_db_url = yamlConfig.get_value("underpass_db_url");

--- a/src/validate/Makefile.am
+++ b/src/validate/Makefile.am
@@ -19,6 +19,7 @@
 # AUTOMAKE_OPTIONS =  -Wno-portability dejagnu subdir-objects
 
 lib_LTLIBRARIES = libunderpass.la
+ETCDIR = $(subst lib,etc,$(pkglibdir))
 
 BOOST_LIBS = $(BOOST_DATE_TIME_LIB) \
 	$(BOOST_SYSTEM_LIB) \
@@ -47,6 +48,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src \
 	-DPKGLIBDIR=\"$(pkglibdir)\" \
 	-DSRCDIR=\"$(srcdir)\" \
+	-DETCDIR=\"$(ETCDIR)\" \
 	-DBOOST_LOCALE_HIDE_AUTO_PTR
 
 install-data-hook:

--- a/src/validate/validate.hh
+++ b/src/validate/validate.hh
@@ -179,7 +179,8 @@ class ValidateStatus {
 class BOOST_SYMBOL_VISIBLE Validate {
   public:
     Validate(void) {
-        std::string path = "/etc/underpass/validate";
+        std::string path = ETCDIR;
+        path += "/validate";
         loadConfig(path);
     }
 


### PR DESCRIPTION
Make the etc directory configurable so it installs without being root. This is also required to build Debian packages.