### PR TITLE
fix: Always uses size_t when comparing with an unsigned int

### DIFF
--- a/src/bootstrap/bootstrap.cc
+++ b/src/bootstrap/bootstrap.cc
@@ -271,7 +271,7 @@ Bootstrap::threadBootstrapWayTask(WayTask wayTask)
     auto wayval = std::make_shared<std::vector<std::shared_ptr<ValidateStatus>>>();
 
     // Proccesing ways
-    for (int i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
+    for (size_t i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
         if (i < ways->size()) {
             auto way = ways->at(i);
             wayval->push_back(validator->checkWay(way, "building"));
@@ -309,7 +309,7 @@ Bootstrap::threadBootstrapNodeTask(NodeTask nodeTask)
 
     // Proccesing nodes
     std::vector<std::string> node_tests = {"building", "natural", "place", "waterway"};
-    for (int i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
+    for (size_t i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
         if (i < nodes->size()) {
             auto node = nodes->at(i);
             for (auto test_it = std::begin(node_tests); test_it != std::end(node_tests); ++test_it) {
@@ -344,7 +344,7 @@ Bootstrap::threadBootstrapRelationTask(RelationTask relationTask)
     // auto relationval = std::make_shared<std::vector<std::shared_ptr<ValidateStatus>>>();
 
     // Proccesing relations
-    for (int i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
+    for (size_t i = taskIndex * page_size; i < (taskIndex + 1) * page_size; ++i) {
         if (i < relations->size()) {
             auto relation = relations->at(i);
             // relationval->push_back(validator->checkRelation(way, "building"));

--- a/src/data/pq.cc
+++ b/src/data/pq.cc
@@ -161,7 +161,7 @@ std::string
 Pq::escapedString(const std::string &s)
 {
     std::string newstr;
-    int i = 0;
+    size_t i = 0;
     while (i < s.size()) {
         // Single quote (')
         if (s[i] == '\'') {

--- a/src/validate/semantic.cc
+++ b/src/validate/semantic.cc
@@ -137,7 +137,7 @@ Semantic::checkNode(const osmobjects::OsmNode &node, const std::string &type, ya
     auto required_tags = tests.get("required_tags");
 
     std::string key;
-    int tagexists = 0;
+    size_t tagexists = 0;
     status->center = node.point;
 
     if (node.tags.count(type)) {
@@ -196,7 +196,7 @@ Semantic::checkWay(const osmobjects::OsmWay &way, const std::string &type, yaml:
         return status;
     }
 
-    int tagexists = 0;
+    size_t tagexists = 0;
     if (way.tags.count(type)) {
         for (auto vit = std::begin(way.tags); vit != std::end(way.tags); ++vit) {
             if (check_badvalue) {
@@ -250,7 +250,7 @@ Semantic::checkRelation(const osmobjects::OsmRelation &relation, const std::stri
         return status;
     }
 
-    int tagexists = 0;
+    size_t tagexists = 0;
     if (relation.tags.count(type)) {
         for (auto vit = std::begin(relation.tags); vit != std::end(relation.tags); ++vit) {
             if (check_badvalue) {


### PR DESCRIPTION
It's not a good idea to compare a signed integer with an unsigned integer