### PR TITLE
Fix deb package building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,8 +31,7 @@ DISTCLEANFILES = docs/html docs/latex .lastmod
 MAINTAINERCLEANFILES = revno.h .lastmod
 ETCDIR = $(subst lib,etc,$(pkglibdir))
 
-SUBDIRS = \
-	src/validate
+SUBDIRS = src/validate
 
 lib_LTLIBRARIES = libunderpass.la
 instdir = /tmp
@@ -50,8 +49,7 @@ BOOST_LIBS = $(BOOST_DATE_TIME_LIB) \
 	$(BOOST_TIMER_LIB) \
 	$(BOOST_PYTHON_LIB)
 
-SQL_FILES = \
-	setup/db/underpass.sql
+SQL_FILES = setup/db/underpass.sql
 
 libunderpass_la_SOURCES = \
 	src/utils/log.cc src/utils/log.hh \
@@ -71,8 +69,7 @@ libunderpass_la_SOURCES = \
 	src/utils/geoutil.cc src/utils/geoutil.hh \
 	src/utils/geo.cc src/utils/geo.hh \
 	src/utils/yaml.hh src/utils/yaml.cc \
-	src/data/pq.hh src/data/pq.cc \
-	setup/db/setupdb.sh
+	src/data/pq.hh src/data/pq.cc
 
 if JEMALLOC
 libunderpass_la_LDFLAGS = -avoid-version -ljemalloc
@@ -109,15 +106,15 @@ AM_CPPFLAGS = \
 # clutter to the output. This should only be enabled when doing performance tuning.
 	-DTIMING_DEBUG
 
-pkgdata_DATA = $(SQL_FILES) setup/db/setupdb.sh $(PYTHON_UTILS)
+pkgdata_DATA = $(SQL_FILES) $(PYTHON_UTILS)
 
 EXTRA_DIST = \
 	$(SQL_FILES) \
 	$(PYTHON_UTILS) \
+	setup/service/underpass.service \
+	setup/db/setupdb.sh \
 	src/testsuite \
-	config/priority.geojson \
-	config/replicator/planetreplicator.yaml \
-	doc \
+	docs \
 	dist/debian \
 	dist/redhat \
 	utils
@@ -154,13 +151,10 @@ endif
 
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(ETCDIR)
-	cp -rvp $(srcdir)/config/priority.geojson  $(DESTDIR)$(ETCDIR)/
-	cp -rvp $(srcdir)/config/replicator  $(DESTDIR)$(ETCDIR)/
-	cp -rvp $(srcdir)/config/stats  $(DESTDIR)$(ETCDIR)/
-	cp -rvp $(srcdir)/config/default.yaml  $(DESTDIR)$(ETCDIR)/
-	cp -rvp $(srcdir)/setup/service $(DESTDIR)/$(pkglibdir)
-	$(MKDIR_P) $(DESTDIR)$(pkglibdir)/../system
-	cp -rvp $(srcdir)/setup/service/underpass.service  $(DESTDIR)$(pkglibdir)/../system/
+	@rsync -avr $(srcdir)/config $(DESTDIR)$(ETCDIR)/
+	@rsync -avr $(srcdir)/setup $(DESTDIR)/$(pkglibdir)
+	@$(MKDIR_P) $(DESTDIR)$(pkglibdir)/../system
+	cp -rvu $(srcdir)/setup/service/underpass.service $(DESTDIR)$(pkglibdir)/../system/
 
 dist-hook: apidoc
 	$(MKDIR_P) $(DESTDIR)/$(docdir)

--- a/dist/debian/changelog
+++ b/dist/debian/changelog
@@ -1,0 +1,5 @@
+underpass (0.3) distro; urgency=low
+
+  * local package.
+
+ -- Rob Savoye (Rollinsville, CO) <rob@senecass.com>  Thu, 04 Apr 2024 04:20:00 +0100

--- a/dist/debian/deb.am
+++ b/dist/debian/deb.am
@@ -34,7 +34,9 @@ DEB_BUILD_OPTIONS ?= $(shell echo $DEB_BUILD_OPTIONS)
 # the file editing to be done
 snapshot-deb:
 	mv $(distdir) $(PACKAGE)-$(NOW)
-	cd  $(PACKAGE)-$(NOW) ; \
-	dpkg-buildpackage -rfakeroot -d -b
+	cd $(PACKAGE)-$(NOW) ; \
+	$(LN_S) dist/debian .; \
+	$(LN_S) $(srcdir)/config .; \
+	dpkg-buildpackage -rfakeroot -d -b -krob@senecass.com
 
 .PHONY : deb snapshot-deb

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -29,7 +29,7 @@ configure: config-stamp
 config-stamp:
 	dh_testdir
 	@printf "\n == CONFIGURE ==\n\n"
-	dh_auto_configure -- CXXFLAGS="-std=c++17 -g -O0" CXX="ccache g++" LDFLAGS="-lbz2"
+	dh_auto_configure -- CXXFLAGS="-std=c++17 -g" CXX="ccache g++" LDFLAGS="-lbz2"
 	touch $@
 
 build: build-stamp

--- a/src/validate/Makefile.am
+++ b/src/validate/Makefile.am
@@ -51,8 +51,8 @@ AM_CPPFLAGS = \
 	-DETCDIR=\"$(ETCDIR)\" \
 	-DBOOST_LOCALE_HIDE_AUTO_PTR
 
-install-data-hook:
-	$(MKDIR_P) $(DESTDIR)/$(pkglibdir)
-	cp -vp .libs/libunderpass.so $(DESTDIR)/$(pkglibdir)
-	$(MKDIR_P) $(DESTDIR)/$(pkglibdir)/config/validate
-	cp -rvp $(top_srcdir)/config/validate/*.yaml $(DESTDIR)/$(pkglibdir)/config/validate
+# install-data-hook:
+# 	$(MKDIR_P) $(DESTDIR)/$(pkglibdir)
+# 	cp -vp .libs/libunderpass.so $(DESTDIR)/$(pkglibdir)
+# 	$(MKDIR_P) $(DESTDIR)/$(pkglibdir)/config/validate
+# 	cp -rvp $(top_srcdir)/config/validate/*.yaml $(DESTDIR)/$(pkglibdir)/config/validate


### PR DESCRIPTION
This fixes building Debian deb packages. Currently it's signed by me (see deb.am), so will need a generic package signer to be useful. It is also possible to externally sign the deb package after running "make deb".