### PR TITLE
Handle two databases

### DIFF
--- a/setup/db/indexes.sql
+++ b/setup/db/indexes.sql
@@ -2,10 +2,6 @@ CREATE UNIQUE INDEX nodes_id_idx ON public.nodes (osm_id DESC);
 CREATE UNIQUE INDEX ways_poly_id_idx ON public.ways_poly (osm_id DESC);
 CREATE UNIQUE INDEX ways_line_id_idx ON public.ways_line(osm_id DESC);
 CREATE UNIQUE INDEX relations_id_idx ON public.relations(osm_id DESC);
-CREATE INDEX way_refs_node_id_idx ON public.way_refs (node_id);
-CREATE INDEX way_refs_way_id_idx ON public.way_refs (way_id);
-CREATE INDEX rel_refs_rel_id_idx ON public.rel_refs (rel_id);
-CREATE INDEX rel_refs_way_id_idx ON public.rel_refs (way_id);
 
 CREATE INDEX nodes_version_idx ON public.nodes (version);
 CREATE INDEX ways_poly_version_idx ON public.ways_poly (version);

--- a/setup/db/underpass.sql
+++ b/setup/db/underpass.sql
@@ -109,25 +109,10 @@ CREATE TABLE IF NOT EXISTS public.relations (
 ALTER TABLE ONLY public.relations
     ADD CONSTRAINT relations_pkey PRIMARY KEY (osm_id);
 
-CREATE TABLE IF NOT EXISTS public.way_refs (
-    way_id int8,
-    node_id int8
-);
-
-CREATE TABLE IF NOT EXISTS public.rel_refs (
-    rel_id int8,
-    way_id int8
-);
-
 CREATE UNIQUE INDEX nodes_id_idx ON public.nodes (osm_id DESC);
 CREATE UNIQUE INDEX ways_poly_id_idx ON public.ways_poly (osm_id DESC);
 CREATE UNIQUE INDEX ways_line_id_idx ON public.ways_line(osm_id DESC);
 CREATE UNIQUE INDEX relations_id_idx ON public.relations(osm_id DESC);
-CREATE INDEX way_refs_node_id_idx ON public.way_refs (node_id);
-CREATE INDEX way_refs_way_id_idx ON public.way_refs (way_id);
-
-CREATE INDEX rel_refs_rel_id_idx ON public.rel_refs (rel_id);
-CREATE INDEX rel_refs_way_id_idx ON public.rel_refs (way_id);
 
 CREATE INDEX nodes_version_idx ON public.nodes (version);
 CREATE INDEX ways_poly_version_idx ON public.ways_poly (version);

--- a/src/bootstrap/bootstrap.cc
+++ b/src/bootstrap/bootstrap.cc
@@ -307,12 +307,6 @@ Bootstrap::threadBootstrapWayTask(WayTask wayTask)
         if (i < ways->size()) {
             auto way = ways->at(i);
             wayval->push_back(validator->checkWay(way, "building"));
-            // Fill the way_refs table
-            if (!norefs) {
-                for (auto ref = way.refs.begin(); ref != way.refs.end(); ++ref) {
-                    task.osmquery.push_back("INSERT INTO way_refs (way_id, node_id) VALUES (" + std::to_string(way.id) + "," + std::to_string(*ref) + "); ");
-                }
-            }
             ++processed;
         }
     }
@@ -320,7 +314,6 @@ Bootstrap::threadBootstrapWayTask(WayTask wayTask)
     auto result = queryvalidate->ways(wayval);
     for (auto it = result->begin(); it != result->end(); ++it) {
         task.query.push_back(*it);
-        log_debug("FOO: %1%", *it);
     }
 
     task.processed = processed;

--- a/src/bootstrap/bootstrap.hh
+++ b/src/bootstrap/bootstrap.hh
@@ -33,18 +33,17 @@ namespace bootstrap {
 /// \struct BootstrapTask
 /// \brief Represents a bootstrap task
 struct BootstrapTask {
-    std::string query = "";
-    std::string osmquery = "";
+    std::vector<std::string> query;
+    std::vector<std::string> osmquery;
     int processed = 0;
 };
 
 /// \struct BootstrapQueries
 /// \brief Represents a bootstrap queries list
 struct BootstrapQueries {
-    std::string underpass = "";
-    std::string osm = "";
+    std::vector<std::string> underpass;
+    std::vector<std::string> osm;
 };
-
 
 struct WayTask {
     int taskIndex;

--- a/src/data/pq.cc
+++ b/src/data/pq.cc
@@ -152,8 +152,16 @@ Pq::query(const std::string &query)
 {
     std::scoped_lock write_lock{pqxx_mutex};
     pqxx::work worker(*sdb);
-    auto result = worker.exec(query);
-    worker.commit();
+    try {
+        auto result = worker.exec(query);
+        worker.commit();
+    } catch (std::exception &e) {
+        log_error("ERROR executing query %1%", e.what());
+        // Return an empty result so higher level code can handle the error
+        pqxx::result result;
+        return result;
+    }
+
     return result;
 }
 

--- a/src/osm/osmchange.cc
+++ b/src/osm/osmchange.cc
@@ -697,7 +697,7 @@ OsmChange::dump(void)
     //         rel->dump();
     //     }
     // }
-    std::cerr << "Final timestamp: " << to_simple_string(final_entry) << std::endl;
+    // std::cerr << "Final timestamp: " << to_simple_string(final_entry) << std::endl;
 
 }
 

--- a/src/raw/queryraw.cc
+++ b/src/raw/queryraw.cc
@@ -320,12 +320,6 @@ QueryRaw::applyChange(const OsmWay &way) const
                 query += fmt.str();
                 queries->push_back(query);
 
-                // Refresh all refs stored into the way_refs table
-                queries->push_back("DELETE FROM way_refs WHERE way_id = " + std::to_string(way.id) + ";");
-                for (auto ref = way.refs.begin(); ref != way.refs.end(); ++ref) {
-                    queries->push_back("INSERT INTO way_refs (way_id, node_id) VALUES (" + std::to_string(way.id) + "," + std::to_string(*ref) + ");");
-                }
-
             } else {
 
                 // Update only the Way's geometry. This is the case when a Way was indirectly 
@@ -368,7 +362,6 @@ QueryRaw::applyChange(const OsmWay &way) const
         }
     } else if (way.action == osmobjects::remove) {
         // Delete a Way geometry and its references.
-        queries->push_back("DELETE FROM way_refs WHERE way_id = " + std::to_string(way.id) + ";");
         if (tableName == &QueryRaw::polyTable) {
             queries->push_back("DELETE FROM " + QueryRaw::polyTable + " where osm_id = " + std::to_string(way.id) + ";");
         } else {
@@ -741,7 +734,7 @@ void QueryRaw::buildGeometries(std::shared_ptr<OsmChangeFile> osmchanges, const 
         std::string nodesQuery = "SELECT osm_id, st_x(geom) as lat, st_y(geom) as lon FROM nodes where osm_id in (" + referencedNodeIds + ");";
         auto result = dbconn->query(nodesQuery);
         if (result.size() == 0) {
-            log_error("No results returned!");
+            log_debug("No results returned!");
             return;
         }
         // Fill nodecache
@@ -848,7 +841,7 @@ QueryRaw::getNodeCacheFromWays(std::shared_ptr<std::vector<OsmWay>> ways, std::m
         std::string nodesQuery = "SELECT osm_id, st_x(geom) as lat, st_y(geom) as lon FROM nodes where osm_id in (" + nodeIds + ") and st_x(geom) is not null and st_y(geom) is not null;";
         auto result = dbconn->query(nodesQuery);
         if (result.size() == 0) {
-            log_error("No results returned!");
+            log_debug("No results returned!");
             return;
         }
 
@@ -885,7 +878,7 @@ QueryRaw::getWaysByNodesRefs(std::string &nodeIds) const
 
         auto ways_result = dbconn->query(*it);
         if (ways_result.size() == 0) {
-            log_error("No results returned!");
+            log_debug("No results returned!");
             return ways;
         }
 
@@ -941,7 +934,7 @@ QueryRaw::getNodesFromDB(long lastid, int pageSize) {
     auto nodes = std::make_shared<std::vector<OsmNode>>();
     auto nodes_result = dbconn->query(nodesQuery);
     if (nodes_result.size() == 0) {
-        log_error("No results returned!");
+        log_debug("No results returned!");
         return nodes;
     }
 
@@ -990,7 +983,7 @@ QueryRaw::getWaysFromDB(long lastid, int pageSize, const std::string &tableName)
     auto ways = std::make_shared<std::vector<OsmWay>>();
     auto ways_result = dbconn->query(waysQuery);
     if (ways_result.size() == 0) {
-        log_error("No results returned!");
+        log_debug("No results returned!");
         return ways;
     }
 
@@ -1045,7 +1038,7 @@ QueryRaw::getWaysFromDBWithoutRefs(long lastid, int pageSize, const std::string 
     auto ways = std::make_shared<std::vector<OsmWay>>();
     auto ways_result = dbconn->query(waysQuery);
     if (ways_result.size() == 0) {
-        log_error("No results returned!");
+        log_debug("No results returned!");
         return ways;
     }
 
@@ -1091,7 +1084,7 @@ QueryRaw::getRelationsFromDB(long lastid, int pageSize) {
     auto relations = std::make_shared<std::vector<OsmRelation>>();
     auto relations_result = dbconn->query(relationsQuery);
     if (relations_result.size() == 0) {
-        log_error("No results returned!");
+        log_debug("No results returned!");
         return relations;
     }
     // Fill vector of OsmRelation objects

--- a/src/raw/queryraw.cc
+++ b/src/raw/queryraw.cc
@@ -170,15 +170,17 @@ std::vector<std::map<std::string, std::string>> parseJSONArrayStr(std::string in
     return arr;
 }
 
+
 // Apply the change for a Node. It will return a string of a query for
 // insert, update or delete the Node in the database.
-std::string
+std::shared_ptr<std::vector<std::string>>
 QueryRaw::applyChange(const OsmNode &node) const
 {
-    std::string query;
+    auto queries = std::make_shared<std::vector<std::string>>();
+
     // If create or modify, then insert or update
     if (node.action == osmobjects::create || node.action == osmobjects::modify) {
-        query = "INSERT INTO nodes as r (osm_id, geom, tags, timestamp, version, \"user\", uid, changeset) VALUES(";
+        std::string query = "INSERT INTO nodes as r (osm_id, geom, tags, timestamp, version, \"user\", uid, changeset) VALUES(";
         std::string format = "%d, ST_GeomFromText(\'%s\', 4326), %s, \'%s\', %d, \'%s\', %d, %d \
         ) ON CONFLICT (osm_id) DO UPDATE SET  geom = ST_GeomFromText(\'%s\', \
         4326), tags = %s, timestamp = \'%s\', version = %d, \"user\" = \'%s\', uid = %d, changeset = %d WHERE r.version < %d;";
@@ -218,14 +220,15 @@ QueryRaw::applyChange(const OsmNode &node) const
         fmt % node.changeset;
         fmt % node.version;
 
-        query += fmt.str();
+        query.append(fmt.str());
+        queries->push_back(query);
 
     // If remove, then delete the object
     } else if (node.action == osmobjects::remove) {
-        query = "DELETE from nodes where osm_id = " + std::to_string(node.id) + ";";
+        queries->push_back("DELETE from nodes where osm_id = " + std::to_string(node.id) + ";");
     }
 
-    return query;
+    return queries;
 }
 
 const std::string QueryRaw::polyTable = "ways_poly";
@@ -233,10 +236,11 @@ const std::string QueryRaw::lineTable = "ways_line";
 
 // Apply the change for a Way. It will return a string of a query for
 // insert, update or delete the Way in the database.
-std::string
+std::shared_ptr<std::vector<std::string>>
 QueryRaw::applyChange(const OsmWay &way) const
 {
-    std::string query = "";
+    auto queries = std::make_shared<std::vector<std::string>>();
+    std::string query;
     const std::string* tableName;
 
     // Get a Polygon or LineString geometry string depending on the Way
@@ -314,11 +318,12 @@ QueryRaw::applyChange(const OsmWay &way) const
                 fmt % way.version;
 
                 query += fmt.str();
+                queries->push_back(query);
 
                 // Refresh all refs stored into the way_refs table
-                query += "DELETE FROM way_refs WHERE way_id=" + std::to_string(way.id) + ";";
+                queries->push_back("DELETE FROM way_refs WHERE way_id = " + std::to_string(way.id) + ";");
                 for (auto ref = way.refs.begin(); ref != way.refs.end(); ++ref) {
-                    query += "INSERT INTO way_refs (way_id, node_id) VALUES (" + std::to_string(way.id) + "," + std::to_string(*ref) + ");";
+                    queries->push_back("INSERT INTO way_refs (way_id, node_id) VALUES (" + std::to_string(way.id) + "," + std::to_string(*ref) + ");");
                 }
 
             } else {
@@ -344,6 +349,7 @@ QueryRaw::applyChange(const OsmWay &way) const
                 fmt % way.id;
 
                 query += fmt.str();
+                queries->push_back(query);
             }
 
             // If the Way's geometry is a LineString, remove all Polygons from the Polygons table.
@@ -358,27 +364,28 @@ QueryRaw::applyChange(const OsmWay &way) const
                 delquery_fmt % QueryRaw::polyTable;
             }
             delquery_fmt % way.id;
-            query += delquery_fmt.str();
+            queries->push_back(delquery_fmt.str());
         }
     } else if (way.action == osmobjects::remove) {
         // Delete a Way geometry and its references.
-        query += "DELETE FROM way_refs WHERE way_id=" + std::to_string(way.id) + ";";
+        queries->push_back("DELETE FROM way_refs WHERE way_id = " + std::to_string(way.id) + ";");
         if (tableName == &QueryRaw::polyTable) {
-            query += "DELETE FROM " + QueryRaw::polyTable + " where osm_id = " + std::to_string(way.id) + ";";
+            queries->push_back("DELETE FROM " + QueryRaw::polyTable + " where osm_id = " + std::to_string(way.id) + ";");
         } else {
-            query += "DELETE FROM " + QueryRaw::lineTable + " where osm_id = " + std::to_string(way.id) + ";";
+            queries->push_back("DELETE FROM " + QueryRaw::lineTable + " where osm_id = " + std::to_string(way.id) + ";");
         }
     }
 
-    return query;
+    return queries;
 }
 
 // Apply the change for a Relation. It will return a string of a query for
 // insert, update or delete the Relation in the database.
-std::string
+std::shared_ptr<std::vector<std::string>>
 QueryRaw::applyChange(const OsmRelation &relation) const
 {
-    std::string query = "";
+    auto queries = std::make_shared<std::vector<std::string>>();
+    std::string query;
 
     // Create, modify or modify the geometry of a Relation
     if (relation.action == osmobjects::create || relation.action == osmobjects::modify || relation.action == osmobjects::modify_geom) {
@@ -444,12 +451,14 @@ QueryRaw::applyChange(const OsmRelation &relation) const
                 fmt % relation.changeset;
                 fmt % relation.version;
 
-                query += fmt.str();
+                query.append(fmt.str());
+                queries->push_back(query);
 
                 // Refresh all refs stored into the rel_refs table
-                query += "DELETE FROM rel_refs WHERE rel_id=" + std::to_string(relation.id) + ";";
+                queries->push_back("DELETE FROM rel_refs WHERE rel_id=" + std::to_string(relation.id) + ";");
+
                 for (auto mit = relation.members.begin(); mit != relation.members.end(); ++mit) {
-                    query += "INSERT INTO rel_refs (rel_id, way_id) VALUES (" + std::to_string(relation.id) + "," + std::to_string(mit->ref) + ");";
+                    queries->push_back("INSERT INTO rel_refs (rel_id, way_id) VALUES (" + std::to_string(relation.id) + "," + std::to_string(mit->ref) + ");");
                 }
 
             } else {
@@ -474,15 +483,16 @@ QueryRaw::applyChange(const OsmRelation &relation) const
                 // osm_id
                 fmt % relation.id;
 
-                query += fmt.str();
+                query.append(fmt.str());
+                queries->push_back(query);
             }
         }
     } else if (relation.action == osmobjects::remove) {
         // Delete a Relation geometry and its references.
-        query += "DELETE FROM relations where osm_id = " + std::to_string(relation.id) + ";";
+        queries->push_back("DELETE FROM relations where osm_id = " + std::to_string(relation.id) + ";");
     }
 
-    return query;
+    return queries;
 }
 
 // Receives a string of comma separated values and
@@ -568,6 +578,10 @@ QueryRaw::getWaysByIds(std::string &waysIds, std::map<long, std::shared_ptr<osmo
     std::string waysQuery = "SELECT distinct(osm_id), ST_AsText(geom, 4326), 'polygon' as type from ways_poly wp where osm_id = any(ARRAY[" + waysIds + "]) ";
     waysQuery += "UNION SELECT distinct(osm_id), ST_AsText(geom, 4326), 'linestring' as type from ways_line wp where osm_id = any(ARRAY[" + waysIds + "])";
     auto ways_result = dbconn->query(waysQuery);
+    if (ways_result.size() == 0) {
+        log_debug("No results returned!");
+        return;
+    }
 
     std::string resultIds = "";
 
@@ -726,6 +740,10 @@ void QueryRaw::buildGeometries(std::shared_ptr<OsmChangeFile> osmchanges, const 
         // Get Nodes geoemtries from DB
         std::string nodesQuery = "SELECT osm_id, st_x(geom) as lat, st_y(geom) as lon FROM nodes where osm_id in (" + referencedNodeIds + ");";
         auto result = dbconn->query(nodesQuery);
+        if (result.size() == 0) {
+            log_error("No results returned!");
+            return;
+        }
         // Fill nodecache
         for (auto node_it = result.begin(); node_it != result.end(); ++node_it) {
             auto node_id = (*node_it)[0].as<long>();
@@ -829,6 +847,10 @@ QueryRaw::getNodeCacheFromWays(std::shared_ptr<std::vector<OsmWay>> ways, std::m
         // Get Nodes geometries from the DB
         std::string nodesQuery = "SELECT osm_id, st_x(geom) as lat, st_y(geom) as lon FROM nodes where osm_id in (" + nodeIds + ") and st_x(geom) is not null and st_y(geom) is not null;";
         auto result = dbconn->query(nodesQuery);
+        if (result.size() == 0) {
+            log_error("No results returned!");
+            return;
+        }
 
         // Fill nodecache with Nodes geometries (Points)
         for (auto node_it = result.begin(); node_it != result.end(); ++node_it) {
@@ -855,6 +877,10 @@ QueryRaw::getWaysByNodesRefs(std::string &nodeIds) const
     std::string waysQuery = "SELECT distinct(osm_id), refs, version, tags, uid, changeset from way_refs join ways_poly wp on wp.osm_id = way_id where node_id = any(ARRAY[" + nodeIds + "])";
     waysQuery += " UNION SELECT distinct(osm_id), refs, version, tags, uid, changeset from way_refs join ways_line wl on wl.osm_id = way_id where node_id = any(ARRAY[" + nodeIds + "]);";
     auto ways_result = dbconn->query(waysQuery);
+    if (ways_result.size() == 0) {
+        log_error("No results returned!");
+        return ways;
+    }
 
     // Create Ways objects and fill the vector
     for (auto way_it = ways_result.begin(); way_it != ways_result.end(); ++way_it) {
@@ -905,9 +931,14 @@ QueryRaw::getNodesFromDB(long lastid, int pageSize) {
     } else {
         nodesQuery += ", version, tags FROM nodes order by osm_id desc limit " + std::to_string(pageSize) + ";";
     }
-    auto nodes_result = dbconn->query(nodesQuery);
-    // Fill vector of OsmNode objects
     auto nodes = std::make_shared<std::vector<OsmNode>>();
+    auto nodes_result = dbconn->query(nodesQuery);
+    if (nodes_result.size() == 0) {
+        log_error("No results returned!");
+        return nodes;
+    }
+
+    // Fill vector of OsmNode objects
     for (auto node_it = nodes_result.begin(); node_it != nodes_result.end(); ++node_it) {
         OsmNode node;
         node.id = (*node_it)[0].as<long>();
@@ -949,9 +980,14 @@ QueryRaw::getWaysFromDB(long lastid, int pageSize, const std::string &tableName)
         waysQuery += ", version, tags FROM " + tableName + " order by osm_id desc limit " + std::to_string(pageSize) + ";";
     }
 
-    auto ways_result = dbconn->query(waysQuery);
-    // Fill vector of OsmWay objects
     auto ways = std::make_shared<std::vector<OsmWay>>();
+    auto ways_result = dbconn->query(waysQuery);
+    if (ways_result.size() == 0) {
+        log_error("No results returned!");
+        return ways;
+    }
+
+    // Fill vector of OsmWay objects
     for (auto way_it = ways_result.begin(); way_it != ways_result.end(); ++way_it) {
         OsmWay way;
         way.id = (*way_it)[0].as<long>();
@@ -999,9 +1035,14 @@ QueryRaw::getWaysFromDBWithoutRefs(long lastid, int pageSize, const std::string 
         waysQuery += ", tags FROM " + tableName + " order by osm_id desc limit " + std::to_string(pageSize) + ";";
     }
 
-    auto ways_result = dbconn->query(waysQuery);
-    // Fill vector of OsmWay objects
     auto ways = std::make_shared<std::vector<OsmWay>>();
+    auto ways_result = dbconn->query(waysQuery);
+    if (ways_result.size() == 0) {
+        log_error("No results returned!");
+        return ways;
+    }
+
+    // Fill vector of OsmWay objects
     for (auto way_it = ways_result.begin(); way_it != ways_result.end(); ++way_it) {
         OsmWay way;
         way.id = (*way_it)[0].as<long>();
@@ -1040,9 +1081,13 @@ QueryRaw::getRelationsFromDB(long lastid, int pageSize) {
         relationsQuery += ", version, tags FROM relations order by osm_id desc limit " + std::to_string(pageSize) + ";";
     }
 
-    auto relations_result = dbconn->query(relationsQuery);
-    // Fill vector of OsmRelation objects
     auto relations = std::make_shared<std::vector<OsmRelation>>();
+    auto relations_result = dbconn->query(relationsQuery);
+    if (relations_result.size() == 0) {
+        log_error("No results returned!");
+        return relations;
+    }
+    // Fill vector of OsmRelation objects
     for (auto rel_it = relations_result.begin(); rel_it != relations_result.end(); ++rel_it) {
         OsmRelation relation;
         relation.id = (*rel_it)[0].as<long>();
@@ -1083,7 +1128,6 @@ QueryRaw::getRelationsFromDB(long lastid, int pageSize) {
 
     return relations;
 }
-
 
 } // namespace queryraw
 

--- a/src/raw/queryraw.hh
+++ b/src/raw/queryraw.hh
@@ -63,11 +63,11 @@ class QueryRaw {
     static const std::string lineTable;
 
     /// Build query for processed Node
-    std::string applyChange(const OsmNode &node) const;
+    std::shared_ptr<std::vector<std::string>> applyChange(const OsmNode &node) const;
     /// Build query for processed Way
-    std::string applyChange(const OsmWay &way) const;
+    std::shared_ptr<std::vector<std::string>> applyChange(const OsmWay &way) const;
     /// Build query for processed Relation
-    std::string applyChange(const OsmRelation &relation) const;
+    std::shared_ptr<std::vector<std::string>> applyChange(const OsmRelation &relation) const;
     /// Build all geometries for a OsmChange file
     void buildGeometries(std::shared_ptr<OsmChangeFile> osmchanges, const multipolygon_t &poly);
     /// Get nodes for filling Node cache from refs on ways 

--- a/src/replicator/threads.hh
+++ b/src/replicator/threads.hh
@@ -96,7 +96,7 @@ struct ReplicationTask {
     std::string url;
     ptime timestamp = not_a_date_time;
     replication::reqfile_t status = replication::reqfile_t::none;
-    std::string query = "";
+    std::vector<std::string> query;
 };
 
 /// This monitors the planet server for new changesets files.

--- a/src/validate/queryvalidate.cc
+++ b/src/validate/queryvalidate.cc
@@ -87,48 +87,52 @@ QueryValidate::QueryValidate(std::shared_ptr<Pq> db) {
     dbconn = db;
 }
 
-std::string
+std::shared_ptr<std::string>
 QueryValidate::updateValidation(std::shared_ptr<std::vector<long>> removals)
 {
 #ifdef TIMING_DEBUG_X
     boost::timer::auto_cpu_timer timer("updateValidation: took %w seconds\n");
 #endif
-    std::string query = "";
+    auto query = std::make_shared<std::string>();
     if (removals->size() > 0) {
-        query = "DELETE FROM validation WHERE osm_id IN(";
+        *query = "DELETE FROM validation WHERE osm_id IN(";
         for (const auto &osm_id : *removals) {
-            query += std::to_string(osm_id) + ",";
+            query->append(std::to_string(osm_id) + ",");
         };
-        query.erase(query.size() - 1);
-        query += ");";
+        query->erase(query->size() - 1);
+        query->append(");");
     }
     return query;
 }
 
-std::string
-QueryValidate::updateValidation(long osm_id, const valerror_t &status, const std::string &source) const
+std::shared_ptr<std::string>
+QueryValidate::updateValidation(long osm_id,
+                                const valerror_t &status,
+                                const std::string &source) const
 {
+    auto query = std::make_shared<std::string>();
     std::string format = "DELETE FROM validation WHERE osm_id = %d and source = '%s' and status = '%s';";
     boost::format fmt(format);
     fmt % osm_id;
     fmt % source;
     fmt % status_list[status];
-    std::string query = fmt.str();
+    *query = fmt.str();
     return query;
 }
 
-std::string
+std::shared_ptr<std::string>
 QueryValidate::updateValidation(long osm_id, const valerror_t &status) const
 {
+    auto query = std::make_shared<std::string>();
     std::string format = "DELETE FROM validation WHERE osm_id = %d and status = '%s';";
     boost::format fmt(format);
     fmt % osm_id;
     fmt % status_list[status];
-    std::string query = fmt.str();
+    *query = fmt.str();
     return query;
 }
 
-std::string
+std::shared_ptr<std::string>
 QueryValidate::applyChange(const ValidateStatus &validation, const valerror_t &status) const
 {
 #ifdef TIMING_DEBUG_X
@@ -137,13 +141,13 @@ QueryValidate::applyChange(const ValidateStatus &validation, const valerror_t &s
     // log_debug("Applying Validation data");
 
     std::string format;
-    std::string query;
+    auto query = std::make_shared<std::string>();
 
     if (validation.values.size() > 0) {
-        query = "INSERT INTO validation as v (osm_id, changeset, uid, type, status, values, timestamp, location, source, version) VALUES(";
+        *query = "INSERT INTO validation as v (osm_id, changeset, uid, type, status, values, timestamp, location, source, version) VALUES(";
         format = "%d, %d, %g, \'%s\', \'%s\', ARRAY[%s], \'%s\', ST_GeomFromText(\'%s\', 4326), \'%s\', %s) ";
     } else {
-        query = "INSERT INTO validation as v (osm_id, changeset, uid, type, status, timestamp, location, source, version) VALUES(";
+        *query = "INSERT INTO validation as v (osm_id, changeset, uid, type, status, timestamp, location, source, version) VALUES(";
         format = "%d, %d, %g, \'%s\', \'%s\', \'%s\', ST_GeomFromText(\'%s\', 4326), \'%s\', %s) ";
     }
     format += "ON CONFLICT (osm_id, status, source) DO UPDATE SET version = %d,  timestamp = \'%s\' WHERE v.version < %d;";
@@ -177,87 +181,86 @@ QueryValidate::applyChange(const ValidateStatus &validation, const valerror_t &s
     fmt % validation.version;
     fmt % to_simple_string(validation.timestamp);
     fmt % validation.version;
-    query += fmt.str();
+    query->append(fmt.str());
 
     return query;
 }
 
-
-void
-QueryValidate::ways(
-    std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval,
-    std::string &task_query
-) {
+std::shared_ptr<std::vector<std::string>>
+QueryValidate::ways(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval) {
+    auto query = std::make_shared<std::vector<std::string>>();
     for (auto it = wayval->begin(); it != wayval->end(); ++it) {
         if (it->get()->status.size() > 0) {
             for (auto status_it = it->get()->status.begin(); status_it != it->get()->status.end(); ++status_it) {
-                task_query += applyChange(*it->get(), *status_it);
+                query->push_back(*applyChange(*it->get(), *status_it));
             }
         }
     }
+    return query;
 }
 
-void
+std::shared_ptr<std::vector<std::string>>
 QueryValidate::ways(
     std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval,
-    std::string &task_query,
     std::shared_ptr<std::vector<long>> validation_removals
 ) {
+    auto query = std::make_shared<std::vector<std::string>>();
     for (auto it = wayval->begin(); it != wayval->end(); ++it) {
         if (it->get()->status.size() > 0) {
             for (auto status_it = it->get()->status.begin(); status_it != it->get()->status.end(); ++status_it) {
-                task_query += applyChange(*it->get(), *status_it);
+                query->push_back(*applyChange(*it->get(), *status_it));
             }
             if (!it->get()->hasStatus(overlapping)) {
-                task_query += updateValidation(it->get()->osm_id, overlapping, "building");
+                query->push_back(*updateValidation(it->get()->osm_id, overlapping, "building"));
             }
             if (!it->get()->hasStatus(duplicate)) {
-                task_query += updateValidation(it->get()->osm_id, duplicate, "building");
+                query->push_back(*updateValidation(it->get()->osm_id, duplicate, "building"));
             }
             if (!it->get()->hasStatus(badgeom)) {
-                task_query += updateValidation(it->get()->osm_id, badgeom, "building");
+                query->push_back(*updateValidation(it->get()->osm_id, badgeom, "building"));
             }
             if (!it->get()->hasStatus(badvalue)) {
-                task_query += updateValidation(it->get()->osm_id, badvalue);
+                query->push_back(*updateValidation(it->get()->osm_id, badvalue));
             }
         } else {
             validation_removals->push_back(it->get()->osm_id);
         }
     }
+    return query;
 }
 
-void
-QueryValidate::nodes(
-    std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval,
-    std::string &task_query
-) {
+std::shared_ptr<std::vector<std::string>>
+QueryValidate::nodes(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval) {
+    auto query = std::make_shared<std::vector<std::string>>();
     for (auto it = nodeval->begin(); it != nodeval->end(); ++it) {
         if (it->get()->status.size() > 0) {
             for (auto status_it = it->get()->status.begin(); status_it != it->get()->status.end(); ++status_it) {
-                task_query += applyChange(*it->get(), *status_it);
+                query->push_back(*applyChange(*it->get(), *status_it));
             }
         }
     }
+    return query;
 }
 
-void
+std::shared_ptr<std::vector<std::string>>
 QueryValidate::nodes(
     std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval,
-    std::string &task_query,
     std::shared_ptr<std::vector<long>> validation_removals
 ) {
+    auto query = std::make_shared<std::vector<std::string>>();
     for (auto it = nodeval->begin(); it != nodeval->end(); ++it) {
         if (it->get()->status.size() > 0) {
             for (auto status_it = it->get()->status.begin(); status_it != it->get()->status.end(); ++status_it) {
-                task_query += applyChange(*it->get(), *status_it);
+                query->push_back(*applyChange(*it->get(), *status_it));
             }
             if (!it->get()->hasStatus(badvalue)) {
-                task_query += updateValidation(it->get()->osm_id, badvalue);
+                query->push_back(*updateValidation(it->get()->osm_id, badvalue));
             }
         } else {
             validation_removals->push_back(it->get()->osm_id);
         }
     }
+    return query;
 }
 
 } // namespace queryvalidate

--- a/src/validate/queryvalidate.hh
+++ b/src/validate/queryvalidate.hh
@@ -74,17 +74,30 @@ class QueryValidate  {
     QueryValidate(std::shared_ptr<Pq> db);
 
     /// Apply data validation to the database
-    std::string applyChange(const ValidateStatus &validation, const valerror_t &status) const;
+    std::shared_ptr<std::string> applyChange(const ValidateStatus &validation,
+                                             const valerror_t &status) const;
     /// Update the validation table, delete any feature that has been fixed.
-    std::string updateValidation(std::shared_ptr<std::vector<long>> removals);
-    std::string updateValidation(long osm_id, const valerror_t &status, const std::string &source) const;
-    std::string updateValidation(long osm_id, const valerror_t &status) const;
-    void ways(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval, std::string &task_query);
-    void nodes(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval, std::string &task_query);
-    void rels(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> relval, std::string &task_query);
-    void ways(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval, std::string &task_query, std::shared_ptr<std::vector<long>> validation_removals);
-    void nodes(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval, std::string &task_query, std::shared_ptr<std::vector<long>> validation_removals);
-    void rels(std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> relval, std::string &task_query, std::shared_ptr<std::vector<long>> validation_removals);
+    std::shared_ptr<std::string> updateValidation(
+        std::shared_ptr<std::vector<long>> removals);
+    std::shared_ptr<std::string> updateValidation(
+        long osm_id, const valerror_t &status, const std::string &source) const;
+    std::shared_ptr<std::string> updateValidation(
+        long osm_id, const valerror_t &status) const;
+    std::shared_ptr<std::vector<std::string>> ways(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval);
+    std::shared_ptr<std::vector<std::string>> ways(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> wayval,
+        std::shared_ptr<std::vector<long>> validation_removals);
+    std::shared_ptr<std::vector<std::string>> nodes(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval);
+    std::shared_ptr<std::vector<std::string>> nodes(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> nodeval,
+        std::shared_ptr<std::vector<long>> validation_removals);
+    std::shared_ptr<std::vector<std::string>> rels(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> relval);
+    std::shared_ptr<std::vector<std::string>> rels(
+        std::shared_ptr<std::vector<std::shared_ptr<ValidateStatus>>> relval,
+        std::shared_ptr<std::vector<long>> validation_removals);
     // Database connection, used for escape strings
     std::shared_ptr<Pq> dbconn;
   };


### PR DESCRIPTION
This completes the previous changes so Underpass works with two databases. One is for the Underpass changesets and validation. The other is for raw OSM data. Previously all the SQL queries were a huge string. This changes the dataflow to use a vector of SQL strings instead, so each query can go to the correct database.