### PR TITLE
fix: timer.hpp got moved, and in the latest Ubuntu, it's now an error

### DIFF
--- a/m4/ax_boost_timer.m4
+++ b/m4/ax_boost_timer.m4
@@ -67,8 +67,8 @@ AC_DEFUN([AX_BOOST_TIMER],
         [AC_LANG_PUSH([C++])
 			 CXXFLAGS_SAVE=$CXXFLAGS
 
-			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/timer.hpp>]],
-                                   [[boost::timer timer;]])],
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/timer/timer.hpp>]],
+                                   [[boost::timer::auto_cpu_timer t;]])],
                    ax_cv_boost_timer=yes, ax_cv_boost_timer=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])


### PR DESCRIPTION
libboost had timer.hpp get moved to it's own subdirectory, and the compile time test was broken as well for current boost 1.83.